### PR TITLE
Feature reactive element selection

### DIFF
--- a/app/components/canvas/canvas-element.css
+++ b/app/components/canvas/canvas-element.css
@@ -16,11 +16,24 @@
   z-index: 2;
 }
 
+.hiddenElement {
+  position: absolute;
+  left: -1000px;
+  visibility: hidden;
+  height: auto;
+  width: auto;
+  white-space: nowrap;
+}
+
+.hide {
+  display: none;
+}
+
 .selected::before {
   content: "";
   position: absolute;
   width: calc(100% + 6px);
-  height: calc(100% + 6px);
+  height: calc(100% + 15%);
   top: -3px;
   left: -3px;
   border: 2px dashed var(--secondary-border-color);

--- a/app/components/canvas/canvas-element.css
+++ b/app/components/canvas/canvas-element.css
@@ -33,7 +33,7 @@
   content: "";
   position: absolute;
   width: calc(100% + 6px);
-  height: calc(100% + 15%);
+  height: calc(100% + 6px);
   top: -3px;
   left: -3px;
   border: 2px dashed var(--secondary-border-color);

--- a/app/components/canvas/canvas-element.css
+++ b/app/components/canvas/canvas-element.css
@@ -16,26 +16,13 @@
   z-index: 2;
 }
 
-.hiddenElement {
-  position: absolute;
-  left: -1000px;
-  visibility: hidden;
-  height: auto;
-  width: auto;
-  white-space: nowrap;
-}
-
-.hide {
-  display: none;
-}
-
 .selected::before {
   content: "";
   position: absolute;
-  width: calc(100% + 6px);
-  height: calc(100% + 6px);
-  top: -3px;
-  left: -3px;
+  width: calc(100% - 2px);
+  height: calc(100% - 2px);
+  top: 0;
+  left: -1px;
   border: 2px dashed var(--secondary-border-color);
   border-radius: 2px;
 }

--- a/app/components/canvas/canvas-element.css
+++ b/app/components/canvas/canvas-element.css
@@ -3,6 +3,7 @@
 .canvasElement {
   position: relative;
   display: inline-block;
+  cursor: move;
 }
 
 /* Need this to capture all click events on elements */

--- a/app/components/canvas/canvas-element.js
+++ b/app/components/canvas/canvas-element.js
@@ -248,7 +248,7 @@ class CanvasElement extends Component {
       this.clickStart = null;
       this.mouseClickTimeout = null;
 
-      this.context.store.updateElementDraggingState(true);
+      this.context.store.updateElementDraggingState(true, true);
 
       // Make the cursor dragging everywhere
       document.body.style.cursor = "-webkit-grabbing";

--- a/app/components/canvas/canvas-element.js
+++ b/app/components/canvas/canvas-element.js
@@ -134,6 +134,7 @@ class CanvasElement extends Component {
     } else {
       change = pageX - resizeLastX;
     }
+
     const newWidth = change + width;
 
     if (newWidth >= 0) {

--- a/app/components/canvas/canvas-element.js
+++ b/app/components/canvas/canvas-element.js
@@ -128,8 +128,6 @@ class CanvasElement extends Component {
     window.removeEventListener("touchmove", this.handleTouchMoveResize);
     window.removeEventListener("touchend", this.handleTouchEndResize);
 
-    document.body.style.cursor = "auto";
-
     this.setState({
       isResizing: false
     });

--- a/app/components/canvas/canvas-element.js
+++ b/app/components/canvas/canvas-element.js
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from "react";
 import ReactDOM from "react-dom";
 import { observer } from "mobx-react";
 import { Motion, spring } from "react-motion";
-import { omit } from "lodash";
+import { omit, defer } from "lodash";
 
 import { ElementTypes, SpringSettings, BLACKLIST_CURRENT_ELEMENT_DESELECT } from "../../constants";
 import { getElementDimensions, getPointsToSnap, snap } from "../../utils";
@@ -41,15 +41,13 @@ class CanvasElement extends Component {
   }
 
   componentDidMount() {
-    const { width, height } = this.currentElementComponent.getBoundingClientRect();
+    defer(() => {
+      const { width, height } = this.currentElementComponent.getBoundingClientRect();
 
-    // add 28px because getBoundingClientReact is firing before
-    // element is finished completely rendering. It is consistently 28px
-    // more narrow than end result. Not sure how to get around this.
-
-    this.setState({ // eslint-disable-line react/no-did-mount-set-state
-      width: (width + 28),
-      height
+      this.setState({ // eslint-disable-line react/no-did-mount-set-state
+        width,
+        height
+      });
     });
   }
 

--- a/app/components/canvas/canvas-element.js
+++ b/app/components/canvas/canvas-element.js
@@ -1,10 +1,12 @@
 import React, { Component, PropTypes } from "react";
 import { observer } from "mobx-react";
 import { Motion, spring } from "react-motion";
+import { omit } from "lodash";
 
 import { ElementTypes, SpringSettings, BLACKLIST_CURRENT_ELEMENT_DESELECT } from "../../constants";
 import { getElementDimensions, getPointsToSnap, snap } from "../../utils";
 import styles from "./canvas-element.css";
+import ResizeNode from "./resize-node";
 
 @observer
 class CanvasElement extends Component {
@@ -43,6 +45,64 @@ class CanvasElement extends Component {
     return true;
   }
 
+  handleTouchResize = (ev) => {
+    ev.preventDefault();
+    this.handleMouseResize(ev.touches[0]);
+  }
+
+  handleMouseUpResize = (ev) => {
+    ev.preventDefault();
+    window.removeEventListener("mousemove", this.handleMouseMoveResize);
+
+    this.setState({ isResizing: false });
+    // update store
+  }
+
+  handleMouseDownResize = (ev) => {
+    ev.stopPropagation();
+    ev.preventDefault();
+
+    const { target, pageX } = ev;
+    const classString = Array.prototype.join.call(target.classList, "");
+    const isLeftSideDrag = classString.indexOf("handleLeft") > -1;
+    const boundingBox = this.currentElementComponent.getBoundingClientRect();
+    const width = this.state.width ? this.state.width : boundingBox.width;
+    const currentElementOffset = isLeftSideDrag ? pageX : pageX + width;
+
+    const updatedState = {
+      currentElementOffset,
+      isLeftSideDrag,
+      isResizing: true,
+      resizeLastX: pageX
+    };
+
+    if (this.state.width === undefined) {
+      updatedState.width = boundingBox.width;
+    }
+
+    if (this.state.height === undefined) {
+      updatedState.height = boundingBox.height;
+    }
+
+    this.setState({ ...updatedState });
+
+    window.addEventListener("mousemove", this.handleMouseMoveResize);
+    window.addEventListener("touchmove", this.handleTouchMoveResize);
+    window.addEventListener("mouseup", this.handleMouseUpResize);
+    window.addEventListener("touchend", this.handleTouchEndResize);
+  }
+
+  handleMouseMoveResize = (ev) => {
+    ev.preventDefault();
+    const { pageX } = ev;
+    const { isLeftSideDrag, resizeLastX, width } = this.state;
+    const change = pageX - resizeLastX;
+
+    if (!isLeftSideDrag) {
+      this.setState({ width: (change + width), resizeLastX: pageX });
+    }
+  }
+
   handleTouchStart = (ev) => {
     ev.preventDefault();
     this.handleMouseDown(ev.touches[0]);
@@ -53,7 +113,9 @@ class CanvasElement extends Component {
     this.handleMouseMove(ev.touches[0]);
   }
 
-  handleMouseMove = ({ pageX, pageY, offsetX, offsetY, target: { id } }) => {
+  handleMouseMove = ({ pageX, pageY, offsetX, offsetY, target }) => {
+    const { id } = target;
+
     const {
       mouseStart: [x, y],
       mouseOffset: [mouseOffsetX, mouseOffsetY],
@@ -126,7 +188,13 @@ class CanvasElement extends Component {
       this.props.component.props.style.top
     ];
 
-    const { width, height } = getElementDimensions(this.props.component);
+    let { width, height } = getElementDimensions(this.props.component);
+    height = (height === undefined) ?
+      this.currentElementComponent.getBoundingClientRect().height :
+      height;
+    width = (width === undefined) ?
+      this.currentElementComponent.getBoundingClientRect().width :
+      width;
 
     window.addEventListener("mouseup", this.handleMouseUp);
     window.addEventListener("touchend", this.handleMouseUp);
@@ -219,6 +287,8 @@ class CanvasElement extends Component {
     } = this.props;
 
     const {
+      width,
+      isResizing,
       isPressed,
       delta: [x, y]
     } = this.state;
@@ -258,30 +328,91 @@ class CanvasElement extends Component {
 
     elementStyle = { ...elementStyle, position: "relative", left: 0, top: 0 };
 
+    if (this.props.component.props.style.width !== undefined) {
+      elementStyle = omit(elementStyle, "whiteSpace");
+      elementStyle.wordBreak = "break-all";
+    }
+
+    const hiddenElementStyle = omit(elementStyle, "height", "width");
+
     if (isPressed) {
       motionStyles.left = spring((props.style && props.style.left || 0) + x, SpringSettings.DRAG);
       motionStyles.top = spring((props.style && props.style.top || 0) + y, SpringSettings.DRAG);
+    }
+
+
+    motionStyles.width = spring((width && width || 220), { stiffness: 210, damping: 20 });
+
+    if (isResizing) {
+      const propWidth = (props.style && props.style.width) || 0;
+      motionStyles.width = spring(Math.round(propWidth + width), { stiffness: 210, damping: 20 });
     }
 
     return (
         <Motion
           style={motionStyles}
         >
-          {computedStyles => (
-            <div
-              className={
-                `${styles.canvasElement} ${extraClasses} ${BLACKLIST_CURRENT_ELEMENT_DESELECT}`
+          {computedStyles => {
+            const computedDragStyles = omit(computedStyles, "width");
+            const computedResizeStyles = omit(computedStyles, "top", "left");
+
+            return (
+            <div>
+              <div
+                ref={component => {this.currentElementComponent = component;}}
+                className={styles.hiddenElement}
+              >
+                {type !== ElementTypes.IMAGE ?
+                  <ComponentClass
+                    {...props}
+                    style={hiddenElementStyle}
+                  >
+                    {children}
+                  </ComponentClass> :
+                  <ComponentClass
+                    {...props}
+                    style={hiddenElementStyle}
+                  />
+                }
+              </div>
+              <div
+                className={
+                  `${styles.canvasElement} ${extraClasses} ${BLACKLIST_CURRENT_ELEMENT_DESELECT}`
+                }
+                style={{ ...wrapperStyle, ...computedDragStyles }}
+                onMouseDown={this.handleMouseDown}
+                onTouchStart={this.handleTouchStart}
+              >
+              {currentlySelected &&
+                <ResizeNode
+                  alignLeft
+                  handleMouseDownResize={this.handleMouseDownResize}
+                  onTouch={this.handleTouchResize}
+                  component={this.props.component}
+                />
               }
-              style={{ ...wrapperStyle, ...computedStyles }}
-              onMouseDown={this.handleMouseDown}
-              onTouchStart={this.handleTouchStart}
-            >
-              {type !== ElementTypes.IMAGE ?
-                <ComponentClass {...props} style={elementStyle}>{children}</ComponentClass> :
-                <ComponentClass {...props} style={elementStyle} />
+                {type !== ElementTypes.IMAGE ?
+                  <ComponentClass
+                    {...props}
+                    style={{ ...elementStyle, ...computedResizeStyles }}
+                  >
+                    {children}
+                  </ComponentClass> :
+                  <ComponentClass
+                    {...props}
+                    style={{ ...elementStyle, ...computedResizeStyles }}
+                  />
+                }
+              {currentlySelected &&
+                <ResizeNode
+                  handleMouseDownResize={this.handleMouseDownResize}
+                  onTouch={this.handleTouchResize}
+                  component={this.props.component}
+                />
               }
+              </div>
             </div>
-          )}
+          );}}
         </Motion>
     );
   }

--- a/app/components/canvas/resize-node.css
+++ b/app/components/canvas/resize-node.css
@@ -3,7 +3,7 @@
   height: 0;
   margin: auto;
   position: absolute;
-  top: -7px;
+  top: -6px;
   width: 7px;
 }
 
@@ -20,9 +20,9 @@
 }
 
 .handleLeft {
-  left: -6px;
+  left: -4px;
 }
 
 .handleRight {
-  right: -9px;
+  right: -4px;
 }

--- a/app/components/canvas/resize-node.css
+++ b/app/components/canvas/resize-node.css
@@ -1,0 +1,28 @@
+.handle {
+  bottom: 0;
+  height: 0;
+  margin: auto;
+  position: absolute;
+  top: -7px;
+  width: 7px;
+}
+
+.handle::before {
+  background: #fff;
+  border: 1px solid #000;
+  box-sizing: border-box;
+  content: "";
+  cursor: pointer;
+  height: 7px;
+  position: absolute;
+  width: 7px;
+  z-index: 5;
+}
+
+.handleLeft {
+  left: -6px;
+}
+
+.handleRight {
+  right: -9px;
+}

--- a/app/components/canvas/resize-node.js
+++ b/app/components/canvas/resize-node.js
@@ -1,6 +1,5 @@
 import React, { Component, PropTypes } from "react";
 import styles from "./resize-node.css";
-import { Motion, spring } from "react-motion";
 
 export default class ResizeNode extends Component {
   static propTypes = {

--- a/app/components/canvas/resize-node.js
+++ b/app/components/canvas/resize-node.js
@@ -1,0 +1,23 @@
+import React, { Component, PropTypes } from "react";
+import styles from "./resize-node.css";
+import { Motion, spring } from "react-motion";
+
+export default class ResizeNode extends Component {
+  static propTypes = {
+    alignLeft: PropTypes.bool,
+    handleMouseDownResize: PropTypes.func
+  }
+
+  render() {
+    return (
+      <div
+        className={
+          `${styles.handle}
+           ${this.props.alignLeft ? styles.handleLeft : styles.handleRight}`
+        }
+        onMouseDown={this.props.handleMouseDownResize}
+        onTouchStart={this.handleTouchResize}
+      ></div>
+    );
+  }
+}

--- a/app/constants/index.js
+++ b/app/constants/index.js
@@ -22,7 +22,8 @@ export const IconTypes = {
 };
 
 export const SpringSettings = {
-  DRAG: { stiffness: 1000, damping: 50 }
+  DRAG: { stiffness: 1000, damping: 50 },
+  RESIZE: { stiffness: 210, damping: 20 }
 };
 
 export const SNAP_DISTANCE = 15;

--- a/app/elements/index.js
+++ b/app/elements/index.js
@@ -41,11 +41,9 @@ elements[ElementTypes.TEXT] = {
       color: "#3d3d3d",
       fontFamily: "openSans",
       fontSize: 45,
-      height: 45,
       fontWeight: 400,
       fontStyle: "normal",
-      textAlign: "center",
-      width: 240
+      textAlign: "center"
     }
   },
   children: "totally text"


### PR DESCRIPTION
@rgerstenberger @kenwheeler, please review. Take note of line 46 of `canvas-element`. I'm open for suggestions on fixes.

- Resizing of element works properly
- Remove default `height` and `width` properties from element, so that border sizes properly
-  Add resize node components.
- If element is resized, store is updated, text wrapping is enabled and that the set width of that element. If content is added, element grows vertically, not horizontally.
- Behavior works properly with multiple elements, font changes, and font-style changes.

![screen shot 2016-06-24 at 12 45 13 pm](https://cloud.githubusercontent.com/assets/8061227/16348842/d2cf62de-3a09-11e6-8934-368397d254ce.png)
![screen shot 2016-06-24 at 12 46 11 pm](https://cloud.githubusercontent.com/assets/8061227/16348841/d2ccb87c-3a09-11e6-8529-c5e56fac6f2f.png)

