### PR TITLE
Position arrange UI in center 

### DIFF
--- a/app/components/canvas/element-types/arrange/index.css
+++ b/app/components/canvas/element-types/arrange/index.css
@@ -11,9 +11,8 @@
 .arrangeContainer {
   position: absolute;
   bottom: calc(100% + 18px);
-  left: 0;
+  left: calc(50% - 100px);
   right: 0;
-  text-align: center;
 }
 
 .arrange {
@@ -24,7 +23,7 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  margin: 0 auto;
+  margin: 0;
   padding: 0;
   position: relative;
   width: 200px;


### PR DESCRIPTION
Fixes bug where arrange UI was not in the center of narrow widths: 
![screen shot 2016-07-19 at 11 12 17 am](https://cloud.githubusercontent.com/assets/768965/16961468/7c095c82-4da2-11e6-85a8-149284a98794.png)

/cc @rgerstenberger (secret css wizard)
