### PR TITLE
Fixes Drag Centering Issue

### DIFF
--- a/app/elements/index.js
+++ b/app/elements/index.js
@@ -35,7 +35,7 @@ elements[ElementTypes.TEXT] = {
   // TODO: Figure out defaults for text element
   type: ElementTypes.TEXT,
   ComponentClass: Heading,
-  defaultWidth: 222,
+  defaultWidth: 90,
   defaultHeight: 63,
   defaultText: ["Text"],
   props: {


### PR DESCRIPTION
@rgerstenberger 

change default width of text element so that it will be centered upon initial drag from top bar