### PR TITLE
Chore refactor text snap to grid

### DIFF
--- a/app/components/canvas/element-types/text-element/index.js
+++ b/app/components/canvas/element-types/text-element/index.js
@@ -482,6 +482,8 @@ export default class TextElement extends Component {
       motionStyles.width = spring(width, SpringSettings.RESIZE);
     }
 
+    const paragraphClass = this.props.component.props.isQuote ? styles.quote : "";
+
     return (
         <Motion
           style={motionStyles}
@@ -525,7 +527,7 @@ export default class TextElement extends Component {
                       this.editable = ReactDOM.findDOMNode(component);
                     }}
                     stopEditing={this.stopEditing}
-                    classNames={{ ...styles }}
+                    classNames={{ ...styles, paragraph: paragraphClass }}
                     isEditing={editing}
                     placeholderText={defaultText}
                     componentProps={{ ...props }}

--- a/app/components/canvas/element-types/text-element/index.js
+++ b/app/components/canvas/element-types/text-element/index.js
@@ -94,6 +94,12 @@ export default class TextElement extends Component {
     const componentLeft = componentProps.style && componentProps.style.left;
     const left = componentLeft || 0;
 
+    if (isLeftSideDrag) {
+      this.rightResizeNode.style.visibility = "hidden";
+    } else {
+      this.leftResizeNode.style.visibility = "hidden";
+    }
+
     this.gridLines = this.context.store.gridLines;
 
     this.setState({
@@ -119,8 +125,8 @@ export default class TextElement extends Component {
   handleMouseMoveResize = (ev) => {
     ev.preventDefault();
     const { pageX } = ev;
-    const { isLeftSideDrag, resizeLastX, width, canvasElementWidth } = this.state;
-    let { left } = this.state;
+    const { isLeftSideDrag, resizeLastX } = this.state;
+    let { left, width, canvasElementWidth } = this.state;
     let change;
     let isSnapped;
 
@@ -130,6 +136,8 @@ export default class TextElement extends Component {
         isSnapped = false;
         return;
       }
+
+      this.props.showGridLine(line, true);
 
       let pointToAlignWithLine;
 
@@ -145,11 +153,19 @@ export default class TextElement extends Component {
         pointToAlignWithLine = Math.ceil(left + canvasElementWidth);
       }
 
-      const distance = Math.abs(pointToAlignWithLine - line);
+      const distance = pointToAlignWithLine - line;
 
-      if (distance <= 3) {
+      if (Math.abs(distance) < 15) {
+        if (isLeftSideDrag) {
+          left -= distance;
+          canvasElementWidth += distance;
+          width += distance;
+        } else {
+          canvasElementWidth -= distance;
+          width -= distance;
+        }
+
         isSnapped = true;
-        this.props.showGridLine(line, true);
       }
     };
 
@@ -163,25 +179,22 @@ export default class TextElement extends Component {
       snapCallback
     );
 
-    if (isSnapped) {
-      return;
-    }
-
     if (isLeftSideDrag) {
       change = resizeLastX - pageX;
-      left -= change;
+      left = isSnapped ? left : left - change;
     } else {
       change = pageX - resizeLastX;
     }
 
-    const newCanvasElementWidth = change + canvasElementWidth;
+    const newCanvasElementWidth = isSnapped ? canvasElementWidth : change + canvasElementWidth;
+    const newWidth = isSnapped ? width : change + width;
 
     if (newCanvasElementWidth >= 0) {
       this.setState({
         left,
-        width: (change + width),
+        width: newWidth,
         canvasElementWidth: newCanvasElementWidth,
-        resizeLastX: pageX
+        resizeLastX: isSnapped ? resizeLastX : pageX
       });
     }
   }
@@ -198,7 +211,8 @@ export default class TextElement extends Component {
     window.removeEventListener("touchmove", this.handleTouchMoveResize);
     window.removeEventListener("touchend", this.handleTouchEndResize);
 
-
+    this.rightResizeNode.style.visibility = "visible";
+    this.leftResizeNode.style.visibility = "visible";
     this.props.hideGridLine(true);
 
     this.context.store.updateElementResizeState(false);
@@ -467,8 +481,6 @@ export default class TextElement extends Component {
       motionStyles.width = spring(width, SpringSettings.RESIZE);
     }
 
-    const paragraphClass = this.props.component.props.isQuote ? styles.quote : "";
-
     return (
         <Motion
           style={motionStyles}
@@ -512,7 +524,7 @@ export default class TextElement extends Component {
                       this.editable = ReactDOM.findDOMNode(component);
                     }}
                     stopEditing={this.stopEditing}
-                    classNames={{ ...styles, paragraph: paragraphClass }}
+                    classNames={{ ...styles }}
                     isEditing={editing}
                     placeholderText={defaultText}
                     componentProps={{ ...props }}
@@ -522,6 +534,7 @@ export default class TextElement extends Component {
                 }
                 {currentlySelected &&
                   <ResizeNode
+                    ref={component => {this.rightResizeNode = ReactDOM.findDOMNode(component);}}
                     alignRight
                     handleMouseDownResize={this.handleMouseDownResize}
                     handleTouchResize={this.handleTouchStartResize}

--- a/app/components/canvas/element-types/text-element/index.js
+++ b/app/components/canvas/element-types/text-element/index.js
@@ -134,6 +134,7 @@ export default class TextElement extends Component {
       if (line === null) {
         this.props.hideGridLine(true);
         isSnapped = false;
+
         return;
       }
 


### PR DESCRIPTION
@rgerstenberger 

Refactor of the text element snap to grid that it works more fluidly and snaps better. Also add the feature of removing other resize node when resizing. 