### PR TITLE
Feature arrange elements

### DIFF
--- a/app/components/canvas/element-types/arrange/index.css
+++ b/app/components/canvas/element-types/arrange/index.css
@@ -3,11 +3,6 @@
   cursor: pointer;
 }
 
-.arrangeButton:focus {
-  background-color: #000;
-  outline: none;
-}
-
 .arrangeContainer {
   position: absolute;
   bottom: calc(100% + 18px);

--- a/app/components/canvas/element-types/arrange/index.css
+++ b/app/components/canvas/element-types/arrange/index.css
@@ -13,6 +13,7 @@
   bottom: calc(100% + 18px);
   left: calc(50% - 100px);
   right: 0;
+  z-index: 100;
 }
 
 .arrange {

--- a/app/components/canvas/element-types/arrange/index.js
+++ b/app/components/canvas/element-types/arrange/index.js
@@ -4,24 +4,24 @@ import { BRINGTOFRONT, BRINGFORWARD, SENDBACKWARD, SENDTOBACK } from "../../../.
 import styles from "./index.css";
 
 class Arrange extends Component {
+  static contextTypes = {
+    store: React.PropTypes.object
+  }
+
   onClickFront = () => {
-    // TODO
-    console.log("Bring to Front!");
+    this.context.store.setCurrentElementToFrontOrBack(true);
   }
 
   onClickForward = () => {
-    // TODO
-    console.log("Increment forward by 1");
+    this.context.store.incrementCurrentElementIndexBy(1);
   }
 
   onClickBackward = () => {
-    // TODO
-    console.log("Decrement backward by 1");
+    this.context.store.incrementCurrentElementIndexBy(-1);
   }
 
   onClickBack = () => {
-    // TODO
-    console.log("Send to back!");
+    this.context.store.setCurrentElementToFrontOrBack();
   }
 
   render() {

--- a/app/components/canvas/element-types/image-element/index.css
+++ b/app/components/canvas/element-types/image-element/index.css
@@ -15,7 +15,7 @@
   bottom: 0;
   left: 0;
 
-  z-index: var(--basic-increment);
+  z-index: 100;
 }
 
 .image {

--- a/app/components/canvas/element-types/image-element/index.css
+++ b/app/components/canvas/element-types/image-element/index.css
@@ -16,6 +16,7 @@
   left: 0;
 
   z-index: 100;
+  pointer-events: none;
 }
 
 .image {

--- a/app/components/canvas/element-types/image-element/index.js
+++ b/app/components/canvas/element-types/image-element/index.js
@@ -582,16 +582,6 @@ export default class ImageElement extends Component {
 
     if (currentlySelected) {
       window.addEventListener("keydown", this.handleKeyDown);
-
-      if (isResizing) {
-        this.currentElementComponent.style.cursor = cursorType;
-      } else if (this.currentElementComponent && !isDragging) {
-        this.currentElementComponent.style.cursor = "move";
-      }
-
-      if (isDragging) {
-        wrapperStyle.pointerEvents = "none";
-      }
     } else {
       window.removeEventListener("keydown", this.handleKeyDown);
       window.removeEventListener("keyup", this.handleKeyUp);
@@ -603,6 +593,15 @@ export default class ImageElement extends Component {
     let elementStyle = props.style ? { ...props.style } : {};
     const { isDragging, isResizing, cursorType } = this.context.store;
 
+    if (currentlySelected && isResizing) {
+      this.currentElementComponent.style.cursor = cursorType;
+    } else if (currentlySelected && this.currentElementComponent && !isDragging) {
+      this.currentElementComponent.style.cursor = "move";
+    }
+
+    if (isDragging) {
+      wrapperStyle.pointerEvents = "none";
+    }
 
     if (mousePosition || props.style && props.style.position === "absolute") {
       wrapperStyle.position = "absolute";

--- a/app/components/canvas/element-types/image-element/index.js
+++ b/app/components/canvas/element-types/image-element/index.js
@@ -42,12 +42,14 @@ export default class ImageElement extends Component {
 
   componentDidMount() {
     defer(() => {
-      const { width, height } = this.currentElementComponent.getBoundingClientRect();
+      if (this.currentElementComponent && !this.context.store.isDragging) {
+        const { width, height } = this.currentElementComponent.getBoundingClientRect();
 
-      this.setState({ // eslint-disable-line react/no-did-mount-set-state
-        width,
-        height
-      });
+        this.setState({ // eslint-disable-line react/no-did-mount-set-state
+          width,
+          height
+        });
+      }
     });
   }
 

--- a/app/components/canvas/element-types/plotly-element/index.css
+++ b/app/components/canvas/element-types/plotly-element/index.css
@@ -19,6 +19,15 @@
   pointer-events: none;
 }
 
+.canvasElement::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+}
+
 .iframe {
   display: block;
 }

--- a/app/components/canvas/element-types/plotly-element/index.css
+++ b/app/components/canvas/element-types/plotly-element/index.css
@@ -19,15 +19,6 @@
   pointer-events: none;
 }
 
-.canvasElement::after {
-  content: "";
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-}
-
 .iframe {
   display: block;
 }

--- a/app/components/canvas/element-types/plotly-element/index.css
+++ b/app/components/canvas/element-types/plotly-element/index.css
@@ -16,6 +16,7 @@
   left: 0;
 
   z-index: 100;
+  pointer-events: none;
 }
 
 .iframe {

--- a/app/components/canvas/element-types/plotly-element/index.css
+++ b/app/components/canvas/element-types/plotly-element/index.css
@@ -15,7 +15,7 @@
   bottom: 0;
   left: 0;
 
-  z-index: var(--basic-increment);
+  z-index: 100;
 }
 
 .iframe {

--- a/app/components/canvas/element-types/plotly-element/index.js
+++ b/app/components/canvas/element-types/plotly-element/index.js
@@ -51,22 +51,6 @@ export default class PlotlyElement extends Component {
     });
   }
 
-  componentWillReceiveProps() {
-    const { isDragging, isResizing } = this.context.store;
-
-    if (!isDragging && !isResizing) {
-      // defer measuring new height and width, otherwise value will be what height was before resize
-      defer(() => {
-        if (this.editable) {
-          this.setState({
-            width: this.editable.clientWidth,
-            height: this.editable.clientHeight
-          });
-        }
-      });
-    }
-  }
-
   shouldComponentUpdate() {
     // This is needed because of the way the component is passed down
     // React isn't re-rendering this when the contextual menu updates the store
@@ -596,6 +580,16 @@ export default class PlotlyElement extends Component {
 
     if (currentlySelected) {
       window.addEventListener("keydown", this.handleKeyDown);
+
+      if (isResizing) {
+        this.currentElementComponent.style.cursor = cursorType;
+      } else if (this.currentElementComponent && !isDragging) {
+        this.currentElementComponent.style.cursor = "move";
+      }
+
+      if (isDragging) {
+        wrapperStyle.pointerEvents = "none";
+      }
     } else {
       window.removeEventListener("keydown", this.handleKeyDown);
       window.removeEventListener("keyup", this.handleKeyUp);
@@ -607,15 +601,6 @@ export default class PlotlyElement extends Component {
     let elementStyle = props.style ? { ...props.style } : {};
     const { isDragging, isResizing, cursorType } = this.context.store;
 
-    if (isResizing) {
-      this.currentElementComponent.style.cursor = cursorType;
-    } else if (this.currentElementComponent && !isDragging) {
-      this.currentElementComponent.style.cursor = "move";
-    }
-
-    if (isDragging) {
-      wrapperStyle.pointerEvents = "none";
-    }
 
     if (mousePosition || props.style && props.style.position === "absolute") {
       wrapperStyle.position = "absolute";
@@ -645,12 +630,12 @@ export default class PlotlyElement extends Component {
 
     elementStyle = { ...elementStyle, position: "relative", left: 0, top: 0 };
 
-    if (isPressed) {
+    if (currentlySelected && isPressed) {
       motionStyles.left = spring((props.style && props.style.left || 0) + x, SpringSettings.DRAG);
       motionStyles.top = spring((props.style && props.style.top || 0) + y, SpringSettings.DRAG);
     }
 
-    if (isResizing) {
+    if (currentlySelected && isResizing) {
       const componentStylesLeft = props.style && props.style.left || 0;
       const componentStylesTop = props.style && props.style.top || 0;
 
@@ -674,7 +659,7 @@ export default class PlotlyElement extends Component {
             const computedDragStyles = omit(computedStyles, "width", "height");
             let computedResizeStyles = omit(computedStyles, "top", "left");
 
-            if (!isResizing) {
+            if (!currentlySelected || !isResizing) {
               computedResizeStyles = {};
             }
 

--- a/app/components/canvas/element-types/plotly-element/index.js
+++ b/app/components/canvas/element-types/plotly-element/index.js
@@ -12,7 +12,7 @@ import styles from "./index.css";
 import ResizeNode from "../../resize-node";
 import Arrange from "../arrange";
 
-export default class ImageElement extends Component {
+export default class PlotlyElement extends Component {
   static propTypes = {
     elementIndex: PropTypes.number,
     component: PropTypes.shape({
@@ -484,16 +484,18 @@ export default class ImageElement extends Component {
   handleMouseDown = (ev) => {
     ev.preventDefault();
 
+    this.clickStart = new Date().getTime();
     this.context.store.setCurrentElementIndex(this.props.elementIndex);
 
-    const { pageX, pageY } = ev;
-    const boundingBox = this.currentElementComponent.getBoundingClientRect();
+    const { pageX, pageY, target } = ev;
+    const boundingBox = target.getBoundingClientRect();
     const mouseOffset = [Math.floor(boundingBox.left - pageX), Math.floor(boundingBox.top - pageY)];
     const originalPosition = [
       this.props.component.props.style.left,
       this.props.component.props.style.top
     ];
-    const { width, height } = boundingBox;
+
+    const { width, height } = this.currentElementComponent.getBoundingClientRect();
 
     window.addEventListener("mouseup", this.handleMouseUp);
     window.addEventListener("touchend", this.handleMouseUp);
@@ -501,28 +503,51 @@ export default class ImageElement extends Component {
     // Do this preemptively so that dragging doesn't take the performance hit
     this.gridLines = this.context.store.gridLines;
 
-    this.context.store.updateElementDraggingState(true, true);
+    // Only do drag if we hold the mouse down for a bit
+    this.mouseClickTimeout = setTimeout(() => {
+      this.clickStart = null;
+      this.mouseClickTimeout = null;
 
-    // Make the cursor dragging everywhere
-    document.body.style.cursor = "-webkit-grabbing";
-    this.currentElementComponent.style.cursor = "-webkit-grabbing";
+      this.context.store.updateElementDraggingState(true, true);
 
-    // TODO: handle elements that aren't absolutely positioned?
-    this.setState({
-      delta: [0, 0],
-      mouseStart: [pageX, pageY],
-      isPressed: true,
-      mouseOffset,
-      originalPosition,
-      width,
-      height
-    });
+      // Make the cursor dragging everywhere
+      document.body.style.cursor = "-webkit-grabbing";
 
-    window.addEventListener("touchmove", this.handleTouchMove);
-    window.addEventListener("mousemove", this.handleMouseMove);
+      // TODO: handle elements that aren't absolutely positioned?
+      this.setState({
+        delta: [0, 0],
+        mouseStart: [pageX, pageY],
+        isPressed: true,
+        mouseOffset,
+        originalPosition,
+        width,
+        height
+      });
+
+      window.addEventListener("touchmove", this.handleTouchMove);
+      window.addEventListener("mousemove", this.handleMouseMove);
+    }, 150);
   }
 
   handleMouseUp = () => {
+    if (this.mouseClickTimeout || this.mouseClickTimeout === 0) {
+      clearTimeout(this.mouseClickTimeout);
+      window.removeEventListener("mouseup", this.handleMouseUp);
+      window.removeEventListener("touchend", this.handleMouseUp);
+
+      this.mouseClickTimeout = null;
+
+      // this.props.onDropElement(this.props.elementType);
+      const timeSinceMouseDown = new Date().getTime() - this.clickStart;
+
+      // Give the user the remainder of the 250ms to do a double click
+      setTimeout(() => {
+        this.clickStart = null;
+      }, 250 - timeSinceMouseDown);
+
+      return;
+    }
+
     window.removeEventListener("touchmove", this.handleTouchMove);
     window.removeEventListener("touchend", this.handleMouseUp);
     window.removeEventListener("mousemove", this.handleMouseMove);
@@ -705,7 +730,7 @@ export default class ImageElement extends Component {
                   <ComponentClass
                     {...props}
                     className={styles.image}
-                    style={{ ...elementStyle, ...computedResizeStyles }}
+                    style={{ ...elementStyle, ...computedResizeStyles, zIndex: elementIndex }}
                   />
                 {currentlySelected &&
                   <ResizeNode

--- a/app/components/canvas/element-types/plotly-element/index.js
+++ b/app/components/canvas/element-types/plotly-element/index.js
@@ -582,16 +582,6 @@ export default class PlotlyElement extends Component {
 
     if (currentlySelected) {
       window.addEventListener("keydown", this.handleKeyDown);
-
-      if (isResizing) {
-        this.currentElementComponent.style.cursor = cursorType;
-      } else if (this.currentElementComponent && !isDragging) {
-        this.currentElementComponent.style.cursor = "move";
-      }
-
-      if (isDragging) {
-        wrapperStyle.pointerEvents = "none";
-      }
     } else {
       window.removeEventListener("keydown", this.handleKeyDown);
       window.removeEventListener("keyup", this.handleKeyUp);
@@ -603,6 +593,15 @@ export default class PlotlyElement extends Component {
     let elementStyle = props.style ? { ...props.style } : {};
     const { isDragging, isResizing, cursorType } = this.context.store;
 
+    if (currentlySelected && isResizing) {
+      this.currentElementComponent.style.cursor = cursorType;
+    } else if (currentlySelected && this.currentElementComponent && !isDragging) {
+      this.currentElementComponent.style.cursor = "move";
+    }
+
+    if (isDragging) {
+      wrapperStyle.pointerEvents = "none";
+    }
 
     if (mousePosition || props.style && props.style.position === "absolute") {
       wrapperStyle.position = "absolute";
@@ -632,7 +631,7 @@ export default class PlotlyElement extends Component {
 
     elementStyle = { ...elementStyle, position: "relative", left: 0, top: 0 };
 
-    if (isPressed) {
+    if (currentlySelected && isPressed) {
       motionStyles.left = spring((props.style && props.style.left || 0) + x, SpringSettings.DRAG);
       motionStyles.top = spring((props.style && props.style.top || 0) + y, SpringSettings.DRAG);
     }
@@ -717,7 +716,12 @@ export default class PlotlyElement extends Component {
                   <ComponentClass
                     {...props}
                     className={styles.image}
-                    style={{ ...elementStyle, ...computedResizeStyles, zIndex: elementIndex }}
+                    style={{
+                      ...elementStyle,
+                      ...computedResizeStyles,
+                      zIndex: elementIndex,
+                      pointerEvents: "none"
+                    }}
                   />
                 {currentlySelected &&
                   <ResizeNode

--- a/app/components/canvas/element-types/plotly-element/index.js
+++ b/app/components/canvas/element-types/plotly-element/index.js
@@ -42,12 +42,14 @@ export default class PlotlyElement extends Component {
 
   componentDidMount() {
     defer(() => {
-      const { width, height } = this.currentElementComponent.getBoundingClientRect();
+      if (this.currentElementComponent && !this.context.store.isDragging) {
+        const { width, height } = this.currentElementComponent.getBoundingClientRect();
 
-      this.setState({ // eslint-disable-line react/no-did-mount-set-state
-        width,
-        height
-      });
+        this.setState({ // eslint-disable-line react/no-did-mount-set-state
+          width,
+          height
+        });
+      }
     });
   }
 
@@ -630,7 +632,7 @@ export default class PlotlyElement extends Component {
 
     elementStyle = { ...elementStyle, position: "relative", left: 0, top: 0 };
 
-    if (currentlySelected && isPressed) {
+    if (isPressed) {
       motionStyles.left = spring((props.style && props.style.left || 0) + x, SpringSettings.DRAG);
       motionStyles.top = spring((props.style && props.style.top || 0) + y, SpringSettings.DRAG);
     }

--- a/app/components/canvas/element-types/text-element/index.css
+++ b/app/components/canvas/element-types/text-element/index.css
@@ -102,4 +102,5 @@ li.line {
 
   border: var(--selected-border);
   border-radius: 2px;
+  z-index: 100;
 }

--- a/app/components/canvas/element-types/text-element/index.css
+++ b/app/components/canvas/element-types/text-element/index.css
@@ -103,4 +103,5 @@ li.line {
   border: var(--selected-border);
   border-radius: 2px;
   z-index: 100;
+  pointer-events: none;
 }

--- a/app/components/canvas/element-types/text-element/index.js
+++ b/app/components/canvas/element-types/text-element/index.js
@@ -501,8 +501,7 @@ export default class TextElement extends Component {
                 className={
                   `${styles.canvasElement}
                    ${extraClasses}
-                   ${BLACKLIST_CURRENT_ELEMENT_DESELECT}
-                   ${styles.list}`
+                   ${BLACKLIST_CURRENT_ELEMENT_DESELECT}`
                 }
                 ref={component => {this.currentElementComponent = component;}}
                 style={{ ...wrapperStyle, ...computedDragStyles }}
@@ -531,7 +530,7 @@ export default class TextElement extends Component {
                     isEditing={editing}
                     placeholderText={defaultText}
                     componentProps={{ ...props }}
-                    style={{ ...elementStyle, ...computedResizeStyles }}
+                    style={{ ...elementStyle, ...computedResizeStyles, zIndex: elementIndex }}
                     children={children}
                   />
                 }

--- a/app/components/canvas/element-types/text-element/index.js
+++ b/app/components/canvas/element-types/text-element/index.js
@@ -379,19 +379,21 @@ export default class TextElement extends Component {
   }
 
   stopEditing = () => {
-    this.setState({
-      editing: false,
-      width: this.currentElementComponent.clientWidth,
-      reRender: true
-    });
+    if (this.currentElementComponent) {
+      this.setState({
+        editing: false,
+        width: this.currentElementComponent.clientWidth,
+        reRender: true
+      });
 
-    // this defer is necessary to force an entire re-render of the text editor
-    // because contentEditable creates new elements outside of react's knowledge.
-    // This will unmount the editor and remount it with the updated children incorporated
-    // into the virtual DOM from the store.
-    defer(() => {
-      this.setState({ reRender: false });
-    });
+      // this defer is necessary to force an entire re-render of the text editor
+      // because contentEditable creates new elements outside of react's knowledge.
+      // This will unmount the editor and remount it with the updated children incorporated
+      // into the virtual DOM from the store.
+      defer(() => {
+        this.setState({ reRender: false });
+      });
+    }
   }
 
   render() {

--- a/app/components/canvas/element-types/text-element/index.js
+++ b/app/components/canvas/element-types/text-element/index.js
@@ -525,6 +525,7 @@ export default class TextElement extends Component {
                     ref={component => {
                       this.editable = ReactDOM.findDOMNode(component);
                     }}
+                    currentlySelected={currentlySelected}
                     stopEditing={this.stopEditing}
                     classNames={{ ...styles, paragraph: paragraphClass }}
                     isEditing={editing}

--- a/app/components/canvas/element-types/text-element/text-content-editor.js
+++ b/app/components/canvas/element-types/text-element/text-content-editor.js
@@ -3,6 +3,7 @@ import React, { Component } from "react";
 export default class TextContentEditor extends Component {
   static propTypes = {
     isEditing: React.PropTypes.bool,
+    currentlySelected: React.PropTypes.bool,
     placeholderText: React.PropTypes.array,
     classNames: React.PropTypes.object,
     componentProps: React.PropTypes.object,
@@ -62,7 +63,6 @@ export default class TextContentEditor extends Component {
     const { content, contentToRender } = this.state;
     const sel = window.getSelection();
     const range = document.createRange();
-
     if (!isEditing) {
       ev.preventDefault();
 
@@ -108,7 +108,8 @@ export default class TextContentEditor extends Component {
     const {
       classNames,
       componentProps,
-      style
+      style,
+      currentlySelected
     } = this.props;
 
     return (
@@ -118,7 +119,7 @@ export default class TextContentEditor extends Component {
         className={classNames.content}
         onBlur={this.handleBlur}
         style={{ ...style, whiteSpace: "pre-wrap" }}
-        contentEditable="true"
+        contentEditable={currentlySelected ? "true" : "false"}
         suppressContentEditableWarning
         onClick={this.handleClick}
         onKeyDown={this.handleKeyDown}
@@ -150,7 +151,7 @@ export default class TextContentEditor extends Component {
   }
 
   renderList(type, text) {
-    const { componentProps, classNames, style } = this.props;
+    const { currentlySelected, componentProps, classNames, style } = this.props;
     let ListTag = "ol";
 
     if (type === "unordered") {
@@ -164,7 +165,7 @@ export default class TextContentEditor extends Component {
         className={`${classNames.content}`}
         onBlur={this.handleBlur}
         style={style}
-        contentEditable="true"
+        contentEditable={currentlySelected ? "true" : "false"}
         suppressContentEditableWarning
         onClick={this.handleClick}
         onBlur={this.handleBlur}

--- a/app/components/canvas/element-types/text-element/text-content-editor.js
+++ b/app/components/canvas/element-types/text-element/text-content-editor.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import { defer } from "lodash";
 
 export default class TextContentEditor extends Component {
   static propTypes = {
@@ -59,12 +60,19 @@ export default class TextContentEditor extends Component {
   }
 
   handleClick = (ev) => {
-    const { isEditing, placeholderText } = this.props;
+    const { isEditing, placeholderText, currentlySelected } = this.props;
     const { content, contentToRender } = this.state;
     const sel = window.getSelection();
     const range = document.createRange();
+
     if (!isEditing) {
       ev.preventDefault();
+
+      return;
+    }
+
+    if (!currentlySelected) {
+      this.props.stopEditing();
 
       return;
     }

--- a/app/components/canvas/element-types/text-element/text-content-editor.js
+++ b/app/components/canvas/element-types/text-element/text-content-editor.js
@@ -1,5 +1,4 @@
 import React, { Component } from "react";
-import { defer } from "lodash";
 
 export default class TextContentEditor extends Component {
   static propTypes = {

--- a/app/components/canvas/resize-node.css
+++ b/app/components/canvas/resize-node.css
@@ -2,7 +2,7 @@
   position: absolute;
 
   margin: auto;
-  z-index: var(--basic-increment);
+  z-index: 100;
 }
 
 .handleLeft::before,

--- a/app/stores/slides-store.js
+++ b/app/stores/slides-store.js
@@ -237,6 +237,57 @@ export default class SlidesStore {
     });
   }
 
+  setCurrentElementToFrontOrBack(toFront) {
+    transaction(() => {
+      const slidesArray = this.slides;
+      const currentChildren = slidesArray[this.currentSlideIndex].children;
+      const currentChild = currentChildren.splice(this.currentElementIndex, 1);
+      let index;
+
+      if (toFront) {
+        slidesArray[this.currentSlideIndex]
+          .children = currentChildren.concat(currentChild);
+        index = slidesArray[this.currentSlideIndex].children.length - 1;
+      } else {
+        slidesArray[this.currentSlideIndex]
+          .children = currentChild.concat(currentChildren);
+        index = 0;
+      }
+
+      this._addToHistory({
+        currentSlideIndex: this.currentSlideIndex,
+        currentElementIndex: index,
+        slides: slidesArray
+      });
+    });
+  }
+
+  incrementCurrentElementIndexBy(num) {
+    const slidesArray = this.slides;
+    const currentChildren = slidesArray[this.currentSlideIndex].children;
+
+    if (
+      num + this.currentElementIndex < 0 ||
+      num + this.currentElementIndex >= currentChildren.length
+    ) {
+      return;
+    }
+
+    transaction(() => {
+      const currentChild = currentChildren[this.currentElementIndex];
+      const sibling = currentChildren[this.currentElementIndex + num];
+
+      currentChildren[this.currentElementIndex] = sibling;
+      currentChildren[this.currentElementIndex + num] = currentChild;
+
+      this._addToHistory({
+        currentSlideIndex: this.currentSlideIndex,
+        currentElementIndex: this.currentElementIndex + num,
+        slides: slidesArray
+      });
+    });
+  }
+
   updateElementDraggingState(isDraggingElement, isDraggingNewElement = false) {
     transaction(() => {
       this.isDragging = isDraggingElement;


### PR DESCRIPTION
@rgerstenberger Arrangement of elements now working. This feature doesn't affect current functionality with drag/drop, text edits, and resizes. Stacking of canvas elements is based upon child render order, and they are re-arranged within the store by manipulating the child Array's order according to user selection.

![screen shot 2016-07-26 at 2 15 25 pm](https://cloud.githubusercontent.com/assets/8061227/17155711/27b09e7c-533b-11e6-9b92-56e3007d9a5b.png)
 
![screen shot 2016-07-26 at 2 15 17 pm](https://cloud.githubusercontent.com/assets/8061227/17155734/3e34130e-533b-11e6-86ef-74de2b3b4e3d.png)

![screen shot 2016-07-26 at 2 15 35 pm](https://cloud.githubusercontent.com/assets/8061227/17155740/443dc006-533b-11e6-8e73-98eaff4fdae9.png)
