### PR TITLE
remove code causing errors on windows, 

### DIFF
--- a/app/components/canvas/element-types/arrange/index.js
+++ b/app/components/canvas/element-types/arrange/index.js
@@ -8,36 +8,16 @@ class Arrange extends Component {
     store: React.PropTypes.object
   }
 
-  onTouchFront = (ev) => {
-    ev.preventDefault();
-    this.onClickFront(ev.touches[0]);
-  }
-
   onClickFront = () => {
     this.context.store.setCurrentElementToFrontOrBack(true);
-  }
-
-  onTouchForward = (ev) => {
-    ev.preventDefault();
-    this.onClickForward(ev.touches[0]);
   }
 
   onClickForward = () => {
     this.context.store.incrementCurrentElementIndexBy(1);
   }
 
-  onTouchBackward = (ev) => {
-    ev.preventDefault();
-    this.onClickBackward(ev.touches[0]);
-  }
-
   onClickBackward = () => {
     this.context.store.incrementCurrentElementIndexBy(-1);
-  }
-
-  onTouchBack = (ev) => {
-    ev.preventDefault();
-    this.onClickBack(ev.touches[0]);
   }
 
   onClickBack = () => {
@@ -51,7 +31,6 @@ class Arrange extends Component {
           <button
             className={styles.arrangeButton}
             onClick={this.onClickFront}
-            onTouchStart={this.onTouchFront}
           >
             <i
               className={styles.arrangeIcon}
@@ -62,7 +41,6 @@ class Arrange extends Component {
           <button
             className={styles.arrangeButton}
             onClick={this.onClickForward}
-            onTouchStart={this.onTouchForward}
           >
             <i
               className={styles.arrangeIcon}
@@ -73,7 +51,6 @@ class Arrange extends Component {
           <button
             className={styles.arrangeButton}
             onClick={this.onClickBackward}
-            onTouchStart={this.onTouchBackward}
           >
             <i
               className={styles.arrangeIcon}
@@ -84,7 +61,6 @@ class Arrange extends Component {
           <button
             className={styles.arrangeButton}
             onClick={this.onClickBack}
-            onTouchStart={this.onTouchBack}
           >
             <i
               className={styles.arrangeIcon}

--- a/app/components/canvas/element-types/arrange/index.js
+++ b/app/components/canvas/element-types/arrange/index.js
@@ -8,16 +8,36 @@ class Arrange extends Component {
     store: React.PropTypes.object
   }
 
+  onTouchFront = (ev) => {
+    ev.preventDefault();
+    this.onClickFront(ev.touches[0]);
+  }
+
   onClickFront = () => {
     this.context.store.setCurrentElementToFrontOrBack(true);
+  }
+
+  onTouchForward = (ev) => {
+    ev.preventDefault();
+    this.onClickForward(ev.touches[0]);
   }
 
   onClickForward = () => {
     this.context.store.incrementCurrentElementIndexBy(1);
   }
 
+  onTouchBackward = (ev) => {
+    ev.preventDefault();
+    this.onClickBackward(ev.touches[0]);
+  }
+
   onClickBackward = () => {
     this.context.store.incrementCurrentElementIndexBy(-1);
+  }
+
+  onTouchBack = (ev) => {
+    ev.preventDefault();
+    this.onClickBack(ev.touches[0]);
   }
 
   onClickBack = () => {
@@ -28,28 +48,44 @@ class Arrange extends Component {
     return (
       <div className={styles.arrangeContainer}>
         <div className={styles.arrange}>
-          <button className={styles.arrangeButton} onClick={this.onClickFront}>
+          <button
+            className={styles.arrangeButton}
+            onClick={this.onClickFront}
+            onTouchStart={this.onTouchFront}
+          >
             <i
               className={styles.arrangeIcon}
               dangerouslySetInnerHTML={{ __html: BRINGTOFRONT }}
               title="Bring to front"
             />
           </button>
-          <button className={styles.arrangeButton} onClick={this.onClickForward}>
+          <button
+            className={styles.arrangeButton}
+            onClick={this.onClickForward}
+            onTouchStart={this.onTouchForward}
+          >
             <i
               className={styles.arrangeIcon}
               dangerouslySetInnerHTML={{ __html: BRINGFORWARD }}
               title="Bring forward"
             />
           </button>
-          <button className={styles.arrangeButton} onClick={this.onClickBackward}>
+          <button
+            className={styles.arrangeButton}
+            onClick={this.onClickBackward}
+            onTouchStart={this.onTouchBackward}
+          >
             <i
               className={styles.arrangeIcon}
               dangerouslySetInnerHTML={{ __html: SENDBACKWARD }}
               title="Send backward"
             />
           </button>
-          <button className={styles.arrangeButton} onClick={this.onClickBack}>
+          <button
+            className={styles.arrangeButton}
+            onClick={this.onClickBack}
+            onTouchStart={this.onTouchBack}
+          >
             <i
               className={styles.arrangeIcon}
               dangerouslySetInnerHTML={{ __html: SENDTOBACK }}

--- a/app/components/canvas/element-types/text-element/index.js
+++ b/app/components/canvas/element-types/text-element/index.js
@@ -432,7 +432,6 @@ export default class TextElement extends Component {
       wrapperStyle.pointerEvents = "none";
     }
 
-
     if (mousePosition || props.style && props.style.position === "absolute") {
       wrapperStyle.position = "absolute";
 

--- a/app/components/canvas/element-types/text-element/text-content-editor.js
+++ b/app/components/canvas/element-types/text-element/text-content-editor.js
@@ -122,7 +122,6 @@ export default class TextContentEditor extends Component {
   renderEditor(contentToRender) {
     const {
       classNames,
-      componentProps,
       style,
       currentlySelected
     } = this.props;
@@ -130,7 +129,6 @@ export default class TextContentEditor extends Component {
     return (
       <div
         ref={(component) => {this.editor = component;}}
-        {...componentProps}
         className={classNames.content}
         onBlur={this.handleBlur}
         style={{ ...style, whiteSpace: "pre-wrap" }}
@@ -166,7 +164,7 @@ export default class TextContentEditor extends Component {
   }
 
   renderList(type, text) {
-    const { currentlySelected, componentProps, classNames, style } = this.props;
+    const { currentlySelected, classNames, style } = this.props;
     let ListTag = "ol";
 
     if (type === "unordered") {
@@ -176,7 +174,6 @@ export default class TextContentEditor extends Component {
     return (
       <ListTag
         ref={(component) => {this.editor = component;}}
-        {...componentProps}
         className={`${classNames.content}`}
         onBlur={this.handleBlur}
         style={style}


### PR DESCRIPTION
@rgerstenberger 

Electron on windows throws an error when spread operator is used to put props on an element  that are not recognized. These changes fix that without affecting functionality. Also, add touch events to arrange component.

![capture](https://cloud.githubusercontent.com/assets/8061227/17199639/2f8055ae-5433-11e6-875b-9e2c13f7163e.PNG)