### PR TITLE
Feature keyboard events

### DIFF
--- a/app/components/canvas/element-types/text-element/index.js
+++ b/app/components/canvas/element-types/text-element/index.js
@@ -516,7 +516,7 @@ export default class TextElement extends Component {
                 onMouseDown={!editing && this.handleMouseDown}
                 onTouchStart={!editing && this.handleTouchStart}
               >
-                {currentlySelected &&
+                {currentlySelected && !editing &&
                   <ResizeNode
                     ref={component => {this.leftResizeNode = ReactDOM.findDOMNode(component);}}
                     alignLeft
@@ -525,7 +525,7 @@ export default class TextElement extends Component {
                     component={this.props.component}
                   />
                 }
-                {currentlySelected && !isResizing && !isDragging &&
+                {currentlySelected && !isResizing && !isDragging && !editing &&
                   <Arrange />
                 }
                 {!this.state.reRender &&
@@ -543,7 +543,7 @@ export default class TextElement extends Component {
                     children={children}
                   />
                 }
-                {currentlySelected &&
+                {currentlySelected && !editing &&
                   <ResizeNode
                     ref={component => {this.rightResizeNode = ReactDOM.findDOMNode(component);}}
                     alignRight

--- a/app/components/canvas/element-types/text-element/index.js
+++ b/app/components/canvas/element-types/text-element/index.js
@@ -337,12 +337,25 @@ export default class TextElement extends Component {
     }, 150);
   }
 
-  handleMouseUp = () => {
+  handleMouseUp = (ev) => {
     const timeSinceMouseDown = new Date().getTime() - this.clickStart;
 
     clearTimeout(this.mouseClickTimeout);
 
-    if (this.clickStart && timeSinceMouseDown <= 150) {
+    // while loop is necessary because the mouseup was preempting the click event on the
+    // arrange buttons and was not firing on them. This ensures that editing mode only
+    // occurs when the mouseup happens on the editor or one of its children.
+    let el = ev.target;
+
+    while (el) {
+      if (el === this.editable) {
+        break;
+      }
+
+      el = el.parentNode;
+    }
+
+    if (el && this.clickStart && timeSinceMouseDown <= 150) {
       window.removeEventListener("mouseup", this.handleMouseUp);
       window.removeEventListener("touchend", this.handleMouseUp);
 

--- a/app/components/canvas/element-types/text-element/text-content-editor.js
+++ b/app/components/canvas/element-types/text-element/text-content-editor.js
@@ -110,12 +110,29 @@ export default class TextContentEditor extends Component {
   }
 
   handleKeyDown = (ev) => {
+    const superKey = process.platform === "darwin" ? ev.metaKey : ev.ctrlKey;
+
+    if (superKey && ev.which === 90) {
+      ev.preventDefault();
+      document.execCommand("undo");
+    }
+
+    if (superKey && ev.which === 90 && ev.shiftKey) {
+      ev.preventDefault();
+      document.execCommand("redo");
+    }
+
     if (ev.which === 8 && ev.target.innerText.length <= 1) {
       ev.preventDefault();
     }
 
     if (ev.which === 13 && ev.shiftKey && !this.props.componentProps.listType) {
       ev.preventDefault();
+    }
+
+    if (ev.which === 27) {
+      ev.preventDefault();
+      this.handleBlur();
     }
   }
 

--- a/app/components/canvas/element-types/text-element/text-content-editor.js
+++ b/app/components/canvas/element-types/text-element/text-content-editor.js
@@ -112,24 +112,31 @@ export default class TextContentEditor extends Component {
   handleKeyDown = (ev) => {
     const superKey = process.platform === "darwin" ? ev.metaKey : ev.ctrlKey;
 
-    if (superKey && ev.which === 90) {
+    // undo super+z, stop propagation so as not to trigger global undo
+    if (superKey && ev.which === 90 && !ev.shiftKey) {
       ev.preventDefault();
+      ev.stopPropagation();
+
       document.execCommand("undo");
     }
 
+    // undo super+shift+z, stop propagation so as not to trigger global redo
     if (superKey && ev.which === 90 && ev.shiftKey) {
       ev.preventDefault();
       document.execCommand("redo");
     }
 
+    // delete prevented so that content editable child element is not deleted
     if (ev.which === 8 && ev.target.innerText.length <= 1) {
       ev.preventDefault();
     }
 
+    // shift+enter new line in when not in list mode doesn't work properly, disabled
     if (ev.which === 13 && ev.shiftKey && !this.props.componentProps.listType) {
       ev.preventDefault();
     }
 
+    // escape will finalze edit.
     if (ev.which === 27) {
       ev.preventDefault();
       this.handleBlur();

--- a/app/components/canvas/element-types/text-element/text-content-editor.js
+++ b/app/components/canvas/element-types/text-element/text-content-editor.js
@@ -1,7 +1,5 @@
 import React, { Component } from "react";
 
-import { isEqual } from "lodash";
-
 export default class TextContentEditor extends Component {
   static propTypes = {
     isEditing: React.PropTypes.bool,
@@ -42,31 +40,6 @@ export default class TextContentEditor extends Component {
 
   handleInput = (ev) => {
     this.setState({ content: ev.target.textContent });
-
-    // add current innerText to history before change
-    if (this.undoOrRedoAction) {
-      this.undoOrRedoAction = false;
-      return;
-    }
-
-    if (!this.history) {
-      this.history = [];
-      this.index = 0;
-    }
-
-    window.clearTimeout(this.inputTimeout);
-
-    this.inputTimeout = window.setTimeout(() => {
-      this.editorChildren = Array.prototype.map.call(this.editor.childNodes, (child) => (
-        child.innerText || ""
-      ));
-
-      if (!isEqual(this.history.slice(-1)[0], this.editorChildren)) {
-        this.history[this.index++] = this.editorChildren;
-      }
-      this.history = this.history.slice(0, this.index);
-      this.index = this.history.length;
-    }, 200);
   }
 
   handleBlur = () => {
@@ -136,75 +109,27 @@ export default class TextContentEditor extends Component {
     this.currentElement = this.context.store.currentElementIndex;
   }
 
-  setEditorStateToString = (content) => {
-    if (!content) {
-      return;
-    }
-
-    const child = this.editor.childNodes[0].cloneNode();
-
-    this.editor.innerHTML = "";
-
-    content.forEach((line) => {
-      const c = child.cloneNode();
-      c.innerText = line;
-      this.editor.appendChild(c);
-    });
-  }
-
-  selectAll = () => {
-    const sel = window.getSelection();
-    const range = document.createRange();
-
-    range.selectNodeContents(this.editor);
-    sel.removeAllRanges();
-    sel.addRange(range);
-  }
-
   handleKeyDown = (ev) => {
     const superKey = process.platform === "darwin" ? ev.metaKey : ev.ctrlKey;
 
-    // super+z
-    if (superKey && !ev.shiftKey && ev.which === 90) {
-      this.undoOrRedoAction = true;
+    if (superKey && ev.which === 90) {
       ev.preventDefault();
-
-      if (this.history && this.history.length && this.index >= 0) {
-        this.setEditorStateToString(this.history[--this.index]);
-        // this.selectAll();
-      }
-
-      if (this.index < 0) {
-        this.index = 0;
-      }
+      document.execCommand("undo");
     }
 
-    // super+shift+z
     if (superKey && ev.which === 90 && ev.shiftKey) {
-      this.undoOrRedoAction = true;
       ev.preventDefault();
-
-      if (this.history && this.history.length && this.index < this.history.length) {
-        this.setEditorStateToString(this.history[++this.index]);
-        // this.selectAll();
-      }
-
-      if (this.index > this.history.length) {
-        this.index = this.history.length;
-      }
+      document.execCommand("redo");
     }
 
-    // delete prevents deleting the first child element
     if (ev.which === 8 && ev.target.innerText.length <= 1) {
       ev.preventDefault();
     }
 
-    // return key prevents default contenteditable behavior
     if (ev.which === 13 && ev.shiftKey && !this.props.componentProps.listType) {
       ev.preventDefault();
     }
 
-    // escape key finalizes and blurs the edit.
     if (ev.which === 27) {
       ev.preventDefault();
       this.handleBlur();
@@ -230,7 +155,6 @@ export default class TextContentEditor extends Component {
         suppressContentEditableWarning
         onClick={this.handleClick}
         onKeyDown={this.handleKeyDown}
-        onKeyUp={this.handleKeyUp}
         onInput={this.handleInput}
       >
         {contentToRender.map((element, i) =>
@@ -278,7 +202,6 @@ export default class TextContentEditor extends Component {
         onClick={this.handleClick}
         onBlur={this.handleBlur}
         onKeyDown={this.handleKeyDown}
-        onKeyUp={this.handleKeyUp}
         onInput={this.handleInput}
       >
         {text.map((element, i) => (

--- a/app/containers/home.js
+++ b/app/containers/home.js
@@ -46,7 +46,9 @@ class Home extends Component {
 
   componentDidMount() {
     autorun(() => {
-      ipcRenderer.send("current-element", !!slideStore.currentElement);
+      if (ipcRenderer && ipcRenderer.send) {
+        ipcRenderer.send("current-element", !!slideStore.currentElement);
+      }
 
       if (fileStore.fileName) {
         // Don't show path info or `.json` extension

--- a/app/containers/home.js
+++ b/app/containers/home.js
@@ -46,6 +46,8 @@ class Home extends Component {
 
   componentDidMount() {
     autorun(() => {
+      ipcRenderer.send("current-element", !!slideStore.currentElement);
+
       if (fileStore.fileName) {
         // Don't show path info or `.json` extension
         document.title = fileStore.fileName.split("/").pop().slice(0, -5);

--- a/app/menu-actions/index.js
+++ b/app/menu-actions/index.js
@@ -112,5 +112,8 @@ export const editActions = {
   },
   redo: (slidesStore) => {
     slidesStore.redo();
+  },
+  delete: (slidesStore) => {
+    slidesStore.deleteCurrentElement();
   }
 };

--- a/app/menu-actions/index.js
+++ b/app/menu-actions/index.js
@@ -115,5 +115,17 @@ export const editActions = {
   },
   delete: (slidesStore) => {
     slidesStore.deleteCurrentElement();
+  },
+  forward: (slidesStore) => {
+    slidesStore.incrementCurrentElementIndexBy(1);
+  },
+  backward: (slidesStore) => {
+    slidesStore.incrementCurrentElementIndexBy(-1);
+  },
+  front: (slidesStore) => {
+    slidesStore.setCurrentElementToFrontOrBack(true);
+  },
+  back: (slidesStore) => {
+    slidesStore.setCurrentElementToFrontOrBack();
   }
 };

--- a/app/stores/slides-store.js
+++ b/app/stores/slides-store.js
@@ -312,6 +312,19 @@ export default class SlidesStore {
     });
   }
 
+  deleteCurrentElement() {
+    if (!this.currentElement) {
+      return;
+    }
+
+    const nextState = this.currentState;
+
+    nextState.slides[this.currentSlideIndex].children.splice(this.currentElementIndex, 1);
+    nextState.currentElementIndex = null;
+
+    this._addToHistory(nextState);
+  }
+
   updateElementDraggingState(isDraggingElement, isDraggingNewElement = false) {
     transaction(() => {
       this.isDragging = isDraggingElement;

--- a/app/stores/slides-store.js
+++ b/app/stores/slides-store.js
@@ -258,6 +258,10 @@ export default class SlidesStore {
   }
 
   setCurrentElementToFrontOrBack(toFront) {
+    if (!this.currentElement) {
+      return;
+    }
+
     transaction(() => {
       const slidesArray = this.slides;
       const currentChildren = slidesArray[this.currentSlideIndex].children;
@@ -289,6 +293,7 @@ export default class SlidesStore {
     const currentChildren = slidesArray[this.currentSlideIndex].children;
 
     if (
+      !this.currentElement ||
       num + this.currentElementIndex < 0 ||
       num + this.currentElementIndex >= currentChildren.length
     ) {

--- a/main.development.js
+++ b/main.development.js
@@ -221,24 +221,6 @@ app.on("ready", () => {
         click() {
           mainWindow.webContents.send("edit", "delete");
         }
-      }, {
-        type: "separator"
-      }, {
-        label: "Cut",
-        accelerator: "Command+X",
-        selector: "cut:"
-      }, {
-        label: "Copy",
-        accelerator: "Command+C",
-        selector: "copy:"
-      }, {
-        label: "Paste",
-        accelerator: "Command+V",
-        selector: "paste:"
-      }, {
-        label: "Select All",
-        accelerator: "Command+A",
-        selector: "selectAll:"
       }]
     }, {
       label: "View",

--- a/main.development.js
+++ b/main.development.js
@@ -80,6 +80,25 @@ app.on("ready", () => {
     });
   });
 
+  ipcMain.on("current-element", (event, isCurrentElement) => {
+    menu.items.forEach((item, i) => {
+      if (item.label === "Edit") {
+        item.submenu.items.forEach((option, k) => {
+          if (
+            option.label === "Move Forward" ||
+            option.label === "Move Backward" ||
+            option.label === "Move To Front" ||
+            option.label === "Move To Back" ||
+            option.label === "Delete Element"
+          ) {
+            menu.items[i].submenu.items[k].enabled = isCurrentElement;
+          }
+        });
+      }
+    });
+    // console.log(menu.items[2].submenu.items);
+  });
+
   ipcMain.on("social-login", (event, socialUrl) => {
     mainWindow.webContents.session.clearStorageData(() => {});
     // Reset the csrftoken cookie if there is one

--- a/main.development.js
+++ b/main.development.js
@@ -155,10 +155,17 @@ app.on("ready", () => {
         }
       }, {
         label: "Redo",
-        accelerator: "Command+Y",
+        accelerator: "Command+Shift+Z",
         selector: "redo:",
         click() {
           mainWindow.webContents.send("edit", "redo");
+        }
+      }, {
+        label: "Delete Element",
+        accelerator: "CMD+D",
+        selector: "delete:",
+        click() {
+          mainWindow.webContents.send("edit", "delete");
         }
       }, {
         type: "separator"
@@ -291,7 +298,10 @@ app.on("ready", () => {
         }
       }, {
         label: "Delete Element",
-        accelerator: ""
+        accelerator: "Ctrl+D",
+        click() {
+          mainWindow.webContents.send("edit", "delete");
+        }
       }]
     },
     {

--- a/main.development.js
+++ b/main.development.js
@@ -255,7 +255,20 @@ app.on("ready", () => {
       submenu: [{
         label: "&Open",
         accelerator: "Ctrl+O"
-      }, {
+      },
+      {
+        label: "&Save",
+        accelerator: "Ctrl+S"
+      },
+      {
+        label: "&Save As...",
+        accelerator: "Ctrl+Shift+S"
+      },
+      {
+        label: "&Export To PDF",
+        accelerator: "Ctrl+W"
+      },
+      {
         label: "&Close",
         accelerator: "Ctrl+W",
         click() {
@@ -263,6 +276,25 @@ app.on("ready", () => {
         }
       }]
     }, {
+      label: "&Edit",
+      submenu: [{
+        label: "&Undo",
+        accelerator: "Ctrl+Z",
+        click() {
+          mainWindow.webContents.send("edit", "undo");
+        }
+      }, {
+        label: "&Redo",
+        accelerator: "Ctrl+Shift+Z",
+        click() {
+          mainWindow.webContents.send("edit", "redo");
+        }
+      }, {
+        label: "Delete Element",
+        accelerator: ""
+      }]
+    },
+    {
       label: "&View",
       submenu: (process.env.NODE_ENV === "development") ? [{
         label: "&Reload",
@@ -276,7 +308,12 @@ app.on("ready", () => {
         click() {
           mainWindow.setFullScreen(!mainWindow.isFullScreen());
         }
-      }, {
+      },
+      {
+        label: "&Slideshow",
+        accelerator: ""
+      },
+      {
         label: "Toggle &Developer Tools",
         accelerator: "Alt+Ctrl+I",
         click() {

--- a/main.development.js
+++ b/main.development.js
@@ -327,11 +327,11 @@ app.on("ready", () => {
       },
       {
         label: "&Export To PDF",
-        accelerator: "Ctrl+W"
+        accelerator: ""
       },
       {
         label: "&Close",
-        accelerator: "Ctrl+W",
+        accelerator: "Ctrl+Q",
         click() {
           mainWindow.close();
         }

--- a/main.development.js
+++ b/main.development.js
@@ -161,6 +161,41 @@ app.on("ready", () => {
           mainWindow.webContents.send("edit", "redo");
         }
       }, {
+        type: "separator"
+      },
+      {
+        label: "Move Forward",
+        accelerator: "CMD+[",
+        selector: "forward:",
+        click() {
+          mainWindow.webContents.send("edit", "forward");
+        }
+      },
+      {
+        label: "Move Backward",
+        accelerator: "CMD+]",
+        selector: "backward:",
+        click() {
+          mainWindow.webContents.send("edit", "backward");
+        }
+      },
+      {
+        label: "Move To Front",
+        accelerator: "shift+CMD+[",
+        selector: "front:",
+        click() {
+          mainWindow.webContents.send("edit", "front");
+        }
+      },
+      {
+        label: "Move To Back",
+        accelerator: "shift+CMD+]",
+        selector: "back:",
+        click() {
+          mainWindow.webContents.send("edit", "back");
+        }
+      },
+      {
         label: "Delete Element",
         accelerator: "CMD+D",
         selector: "delete:",
@@ -296,7 +331,39 @@ app.on("ready", () => {
         click() {
           mainWindow.webContents.send("edit", "redo");
         }
-      }, {
+      },
+      {
+        type: "separator"
+      },
+      {
+        label: "&Move Forward",
+        accelerator: "Ctrl+[",
+        click() {
+          mainWindow.webContents.send("edit", "forward");
+        }
+      },
+      {
+        label: "&Move Backward",
+        accelerator: "Ctrl+]",
+        click() {
+          mainWindow.webContents.send("edit", "backward");
+        }
+      },
+      {
+        label: "&Move To Front",
+        accelerator: "shift+Ctrl+[",
+        click() {
+          mainWindow.webContents.send("edit", "front");
+        }
+      },
+      {
+        label: "&Move To Back",
+        accelerator: "shift+Ctrl+]",
+        click() {
+          mainWindow.webContents.send("edit", "back");
+        }
+      },
+      {
         label: "Delete Element",
         accelerator: "Ctrl+D",
         click() {


### PR DESCRIPTION
@rgerstenberger 

Undo, redo, and escape to finalize have been implemented on text editor. The undo/redo functionality is only partially working, due to some faulty issues with `execCommand("redo")` not repeating all actions for some reason. In the interest of time it was decided not to pursue creating a history stack for the text editor and implementing undo/redo functionality from scratch as it was slowing productivity. We can circle back to this as you like, and I can file an issue as well. Otherwise, I or someone else can tackle it ASAP.

remove resize nodes and arrange component when editing.

Add menu items for windows and Mac with keyboard events and enabled/disabled context based upon element selection.

![screen shot 2016-07-28 at 3 17 24 pm](https://cloud.githubusercontent.com/assets/8061227/17231331/21b82c28-54d6-11e6-99dd-72db7d942ee3.png)
![screen shot 2016-07-28 at 3 17 35 pm](https://cloud.githubusercontent.com/assets/8061227/17231330/21b6a8e4-54d6-11e6-9037-f89ebf45f3c2.png)




