### PR TITLE
Feature center new elements

### DIFF
--- a/app/components/canvas/index.js
+++ b/app/components/canvas/index.js
@@ -148,12 +148,28 @@ class SlideList extends Component {
       const height = element.defaultHeight || element.props.height;
       const width = element.defaultWidth || element.props.width;
 
+      let left = (slideElement.clientWidth / 2) - (width / 2);
+      let top = (slideElement.clientHeight / 2) - (height / 2);
+
+      const positions =
+        this.context.store.currentSlide.children.reduce((positionHashMap, child) => {
+          const key = `${child.props.style.left}x${child.props.style.top}`;
+          positionHashMap[key] = true; // eslint-disable-line no-param-reassign
+
+          return positionHashMap;
+        }, {});
+
+      while (positions[`${left}x${top}`]) {
+        left += 10;
+        top += 10;
+      }
+
       this.context.store.dropElement(elementType, {
         style: {
           whiteSpace: "nowrap",
           position: "absolute",
-          left: (slideElement.clientWidth / 2) - (width / 2),
-          top: (slideElement.clientHeight / 2) - (height / 2)
+          left,
+          top
         }
       });
 

--- a/app/components/canvas/index.js
+++ b/app/components/canvas/index.js
@@ -143,13 +143,17 @@ class SlideList extends Component {
     this.gridLines = null;
 
     if (!position) {
+      const slideElement = findDOMNode(this.refs.slide);
+      const element = Elements[elementType];
+      const height = element.defaultHeight || element.props.height;
+      const width = element.defaultWidth || element.props.width;
+
       this.context.store.dropElement(elementType, {
         style: {
           whiteSpace: "nowrap",
           position: "absolute",
-          // TODO: Place in center of slide
-          left: 0,
-          top: 0
+          left: (slideElement.clientWidth / 2) - (width / 2),
+          top: (slideElement.clientHeight / 2) - (height / 2)
         }
       });
 


### PR DESCRIPTION
@rgerstenberger new elements now center on the slide when they are created. If a current element is already in that position, it is placed 10 pixels down and 10 pixels right.
<img width="372" alt="screen shot 2016-07-29 at 4 34 28 pm" src="https://cloud.githubusercontent.com/assets/8061227/17266189/2b814198-55aa-11e6-8fb2-f68faa8acd3f.png">
<img width="708" alt="screen shot 2016-07-29 at 4 34 51 pm" src="https://cloud.githubusercontent.com/assets/8061227/17266198/35e74448-55aa-11e6-8b86-7b758459bea5.png">
