### PR TITLE
prevent document title from continuously appending after every edit

### DIFF
--- a/app/containers/home.js
+++ b/app/containers/home.js
@@ -55,7 +55,7 @@ class Home extends Component {
         document.title = fileStore.fileName.split("/").pop().slice(0, -5);
       }
 
-      if (fileStore.isDirty) {
+      if (fileStore.isDirty && !document.title.match(/\* - Edited$/)) {
         document.title += "* - Edited";
       }
     });


### PR DESCRIPTION
@rgerstenberger quick fix to ensure that title append reflects edited state properly