### PR TITLE
Fix copy paste

### DIFF
--- a/main.development.js
+++ b/main.development.js
@@ -308,7 +308,7 @@ app.on("ready", () => {
       },
       {
         label: "Delete Element",
-        accelerator: "CMD+D",
+        accelerator: "Backspace",
         selector: "delete:",
         click() {
           mainWindow.webContents.send("edit", "delete");
@@ -508,7 +508,7 @@ app.on("ready", () => {
       },
       {
         label: "Delete Element",
-        accelerator: "Ctrl+D",
+        accelerator: "Backspace",
         click() {
           mainWindow.webContents.send("edit", "delete");
         }

--- a/main.development.js
+++ b/main.development.js
@@ -313,6 +313,25 @@ app.on("ready", () => {
         click() {
           mainWindow.webContents.send("edit", "delete");
         }
+      },
+      {
+        type: "separator"
+      }, {
+        label: "Cut",
+        accelerator: "Command+X",
+        selector: "cut:"
+      }, {
+        label: "Copy",
+        accelerator: "Command+C",
+        selector: "copy:"
+      }, {
+        label: "Paste",
+        accelerator: "Command+V",
+        selector: "paste:"
+      }, {
+        label: "Select All",
+        accelerator: "Command+A",
+        selector: "selectAll:"
       }]
     }, {
       label: "View",


### PR DESCRIPTION
fix `copy`/`paste` bug, is necessary to have them embedded into app menu for them to work. Added `cut` and `select-all` as well. "Delete Element" is now `Backspace` unable to test on Linux and Windows at the moment, but works on Mac and doesn't interfere with `backspace` during text edits.

