### PR TITLE
Fix merge paragraph styles

### DIFF
--- a/app/components/canvas/element-types/text-element/index.js
+++ b/app/components/canvas/element-types/text-element/index.js
@@ -213,7 +213,10 @@ export default class TextElement extends Component {
     const propStyles = { ...this.props.component.props.style };
 
     propStyles.width = width;
+    propStyles.whiteSpace = "normal";
+    propStyles.wordBreak = "break-all";
     propStyles.left = left;
+
     this.context.store.updateElementProps({ style: propStyles });
   }
 
@@ -453,10 +456,14 @@ export default class TextElement extends Component {
       top: 0
     };
 
-    if (this.props.component.props.style.width !== undefined || isResizing) {
-      elementStyle = omit(elementStyle, "whiteSpace");
+    if (this.props.component.props.style.width === undefined && currentlySelected && isResizing) {
+      elementStyle.whiteSpace = "normal";
       elementStyle.wordBreak = "break-all";
     }
+    // if (this.props.component.props.style.width !== undefined || isResizing) {
+    //   elementStyle = omit(elementStyle, "whiteSpace");
+    //   elementStyle.wordBreak = "break-all";
+    // }
 
     if (isPressed) {
       motionStyles.left =

--- a/app/components/canvas/element-types/text-element/index.js
+++ b/app/components/canvas/element-types/text-element/index.js
@@ -460,10 +460,6 @@ export default class TextElement extends Component {
       elementStyle.whiteSpace = "normal";
       elementStyle.wordBreak = "break-all";
     }
-    // if (this.props.component.props.style.width !== undefined || isResizing) {
-    //   elementStyle = omit(elementStyle, "whiteSpace");
-    //   elementStyle.wordBreak = "break-all";
-    // }
 
     if (isPressed) {
       motionStyles.left =

--- a/app/components/canvas/element-types/text-element/text-content-editor.js
+++ b/app/components/canvas/element-types/text-element/text-content-editor.js
@@ -123,6 +123,8 @@ export default class TextContentEditor extends Component {
     // undo super+shift+z, stop propagation so as not to trigger global redo
     if (superKey && ev.which === 90 && ev.shiftKey) {
       ev.preventDefault();
+      ev.stopPropagation();
+
       document.execCommand("redo");
     }
 

--- a/app/stores/slides-store.js
+++ b/app/stores/slides-store.js
@@ -487,9 +487,9 @@ export default class SlidesStore {
         this.fileStore.setIsDirty(true);
       }
     });
-    console.log(extendParagraphStylesForTextElements(this.slides, this.paragraphStyles));
+
     ipcRenderer.send("update-presentation", {
-      slides: this.slides,
+      slides: extendParagraphStylesForTextElements(this.slides, this.paragraphStyles),
       currentSlideIndex: this.currentSlideIndex
     });
   }

--- a/app/stores/slides-store.js
+++ b/app/stores/slides-store.js
@@ -6,7 +6,11 @@ import { merge, mergeWith, pick, omit } from "lodash";
 
 import ApiStore from "./api-store";
 import elementMap from "../elements";
-import { getParagraphStyles, getGridLinesObj, getGridLineHashes } from "../utils";
+import { getParagraphStyles,
+  extendParagraphStylesForTextElements,
+  getGridLinesObj,
+  getGridLineHashes
+} from "../utils";
 
 const defaultParagraphStyles = {
   "Heading 1": getParagraphStyles({ fontSize: 26 }),
@@ -140,7 +144,7 @@ export default class SlidesStore {
 
     ipcRenderer.on("trigger-update", () => {
       ipcRenderer.send("update-presentation", {
-        slides: this.slides,
+        slides: extendParagraphStylesForTextElements(this.slides, this.paragraphStyles),
         currentSlideIndex: this.currentSlideIndex
       });
     });
@@ -483,7 +487,7 @@ export default class SlidesStore {
         this.fileStore.setIsDirty(true);
       }
     });
-
+    console.log(extendParagraphStylesForTextElements(this.slides, this.paragraphStyles));
     ipcRenderer.send("update-presentation", {
       slides: this.slides,
       currentSlideIndex: this.currentSlideIndex

--- a/app/stores/slides-store.js
+++ b/app/stores/slides-store.js
@@ -144,7 +144,10 @@ export default class SlidesStore {
 
     ipcRenderer.on("trigger-update", () => {
       ipcRenderer.send("update-presentation", {
-        slides: extendParagraphStylesForTextElements(this.slides, this.paragraphStyles),
+        slides: extendParagraphStylesForTextElements(
+          this.slides,
+          this.history[this.historyIndex].paragraphStyles
+        ),
         currentSlideIndex: this.currentSlideIndex
       });
     });
@@ -489,7 +492,10 @@ export default class SlidesStore {
     });
 
     ipcRenderer.send("update-presentation", {
-      slides: extendParagraphStylesForTextElements(this.slides, this.paragraphStyles),
+      slides: extendParagraphStylesForTextElements(
+        this.slides,
+        this.history[this.historyIndex].paragraphStyles
+      ),
       currentSlideIndex: this.currentSlideIndex
     });
   }

--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -20,16 +20,20 @@ export const getParagraphStyles = (obj) => (
 export const extendParagraphStylesForTextElements = (slides, paragaphStyles) => {
   const clonedSlides = cloneDeep(slides);
 
-  clonedSlides.forEach((slide, i) => {
-    slide.children.forEach((child, k) => {
-      if (child.type === ElementTypes.TEXT) {
-        clonedSlides[i].children[k].props.style = {
-          ...paragaphStyles[child.props.paragraphStyle],
-          ...child.props.style
-        };
+  if (clonedSlides) {
+    clonedSlides.forEach((slide, i) => {
+      if (slide.children) {
+        slide.children.forEach((child, k) => {
+          if (child.type === ElementTypes.TEXT) {
+            clonedSlides[i].children[k].props.style = {
+              ...paragaphStyles[child.props.paragraphStyle],
+              ...child.props.style
+            };
+          }
+        });
       }
     });
-  });
+  }
 
   return clonedSlides;
 };

--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -17,22 +17,23 @@ export const getParagraphStyles = (obj) => (
   }
 );
 
-export const extendParagraphStylesForTextElements = (slides, paragaphStyles) =>
-  slides.map(slide =>
-    slide.children.map(child => {
-      // if (child.type === ElementTypes.TEXT) {
-      //   const textElement = cloneDeep(child);
+export const extendParagraphStylesForTextElements = (slides, paragaphStyles) => {
+  const clonedSlides = cloneDeep(slides);
 
-      //   textElement.props.style = {
-      //     ...paragaphStyles[child.props.paragraphStyle],
-      //     ...child.props.style
-      //   };
+  clonedSlides.forEach((slide, i) => {
+    slide.children.forEach((child, k) => {
+      if (child.type === ElementTypes.TEXT) {
+        clonedSlides[i].children[k].props.style = {
+          ...paragaphStyles[child.props.paragraphStyle],
+          ...child.props.style
+        };
+      }
+    });
+  });
 
-      //   return textElement;
-      // }
+  return clonedSlides;
+};
 
-      return child;
-    }));
 
 export const getElementDimensions = ({ type, props }) => {
   if (type === ElementTypes.TEXT) {

--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -1,4 +1,4 @@
-import { sortBy, sortedUniq, invert } from "lodash";
+import { sortBy, cloneDeep, sortedUniq, invert } from "lodash";
 
 import { ElementTypes, SNAP_DISTANCE } from "../constants";
 
@@ -16,6 +16,23 @@ export const getParagraphStyles = (obj) => (
     ...obj
   }
 );
+
+export const extendParagraphStylesForTextElements = (slides, paragaphStyles) =>
+  slides.map(slide =>
+    slide.children.map(child => {
+      // if (child.type === ElementTypes.TEXT) {
+      //   const textElement = cloneDeep(child);
+
+      //   textElement.props.style = {
+      //     ...paragaphStyles[child.props.paragraphStyle],
+      //     ...child.props.style
+      //   };
+
+      //   return textElement;
+      // }
+
+      return child;
+    }));
 
 export const getElementDimensions = ({ type, props }) => {
   if (type === ElementTypes.TEXT) {


### PR DESCRIPTION
@kenwheeler fix undo/redo during text editing, extend paragraph styles to cloned text elements for presentation mode and pdf export, explicitly add css properties for word break after resize is complete rather than during render method, (unless during drag state, which is necessary).