### PR TITLE
Pin ChromeDriver to v2.21.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "babel-preset-stage-0": "^6.5.0",
     "babel-register": "^6.7.2",
     "chai": "^3.5.0",
-    "chromedriver": "^2.21.2",
+    "chromedriver": "2.21.2",
     "co-mocha": "^1.1.2",
     "concurrently": "^2.0.0",
     "cross-env": "^1.0.7",


### PR DESCRIPTION
There's an installation issue with ChromeDriver v2.23.0. Pin to old, working version.

@mdaxtman 