### PR TITLE
Improve handling of paragraphStyles

### DIFF
--- a/app/stores/slides-store.js
+++ b/app/stores/slides-store.js
@@ -7,7 +7,6 @@ import { merge, mergeWith, pick, omit } from "lodash";
 import ApiStore from "./api-store";
 import elementMap from "../elements";
 import { getParagraphStyles,
-  extendParagraphStylesForTextElements,
   getGridLinesObj,
   getGridLineHashes
 } from "../utils";
@@ -145,10 +144,8 @@ export default class SlidesStore {
 
     ipcRenderer.on("trigger-update", () => {
       ipcRenderer.send("update-presentation", {
-        slides: extendParagraphStylesForTextElements(
-          this.slides,
-          this.history[this.historyIndex].paragraphStyles
-        ),
+        slides: this.slides,
+        paragraphStyles: this.history[this.historyIndex].paragraphStyles,
         currentSlideIndex: this.currentSlideIndex
       });
     });
@@ -493,10 +490,8 @@ export default class SlidesStore {
     });
 
     ipcRenderer.send("update-presentation", {
-      slides: extendParagraphStylesForTextElements(
-        this.slides,
-        this.history[this.historyIndex].paragraphStyles
-      ),
+      slides: this.slides,
+      paragraphStyles: this.history[this.historyIndex].paragraphStyles,
       currentSlideIndex: this.currentSlideIndex
     });
   }

--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -8,7 +8,7 @@ export const getParagraphStyles = (obj) => (
     fontFamily: "openSans",
     fontSize: 45,
     fontStyle: "normal",
-    lineHeight: 1,
+    lineHeight: "normal",
     fontWeight: 400,
     minWidth: 20,
     opacity: 1,
@@ -17,28 +17,6 @@ export const getParagraphStyles = (obj) => (
     ...obj
   }
 );
-
-export const extendParagraphStylesForTextElements = (slides, paragaphStyles) => {
-  const clonedSlides = cloneDeep(slides);
-
-  if (clonedSlides) {
-    clonedSlides.forEach((slide, i) => {
-      if (slide.children) {
-        slide.children.forEach((child, k) => {
-          if (child.type === ElementTypes.TEXT) {
-            clonedSlides[i].children[k].props.style = {
-              ...paragaphStyles[child.props.paragraphStyle],
-              ...child.props.style
-            };
-          }
-        });
-      }
-    });
-  }
-
-  return clonedSlides;
-};
-
 
 export const getElementDimensions = ({ type, props }) => {
   if (type === ElementTypes.TEXT) {

--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -8,6 +8,7 @@ export const getParagraphStyles = (obj) => (
     fontFamily: "openSans",
     fontSize: 45,
     fontStyle: "normal",
+    lineHeight: 1,
     fontWeight: 400,
     minWidth: 20,
     opacity: 1,

--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -1,4 +1,4 @@
-import { sortBy, cloneDeep, sortedUniq, invert } from "lodash";
+import { sortBy, sortedUniq, invert } from "lodash";
 
 import { ElementTypes, SNAP_DISTANCE } from "../constants";
 

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "shortid": "^2.2.6",
     "source-map-support": "^0.4.0",
     "spectacle": "^1.0.6",
-    "spectacle-editor-viewer": "0.0.14"
+    "spectacle-editor-viewer": "0.0.16"
   },
   "devEngines": {
     "node": "4.x || 5.x || 6.x",


### PR DESCRIPTION
With the version bump of spectacle-editor-viewer, merging paragraphStyles with text nodes is no longer needed. This also specifies a default lineHeight, which was responsible for a rendering difference between the editor and the viewer. 

/cc @mdaxtman @rgerstenberger 