### PR TITLE
add scaling for gridlines for child element height and width

### DIFF
--- a/app/utils/index.js
+++ b/app/utils/index.js
@@ -81,11 +81,13 @@ export const generateClosestHash = (arr) => (
 
 export const getGridLinesObj = (elements, horizontalInitial, verticalInitial, scale) => (
   elements.reduce((gridObj, element) => {
-    const { width, height } = getElementDimensions(element);
+    let { width, height } = getElementDimensions(element);
     let { top, left } = getElementLocation(element);
 
     top *= scale;
     left *= scale;
+    width *= scale;
+    height *= scale;
     // TODO: don't use grid lines of elements off the canvas e.g.
     // TODO: Set all grid lines of elements off the slide to 0
 


### PR DESCRIPTION
@bmathews gridlines were not working properly before because height and width were not being scaled properly for elements with those defined values. Fixes #154 