### PR TITLE
fix multi-lines vanishing when exiting edit mode

### DIFF
--- a/app/components/canvas/element-types/text-element/text-content-editor.js
+++ b/app/components/canvas/element-types/text-element/text-content-editor.js
@@ -179,7 +179,7 @@ export default class TextContentEditor extends Component {
                   className={classNames.line}
                   key={k}
                 >
-                  {line}
+                  {line === "" ? <br /> : line}
                 </span>
               )
             )}

--- a/app/components/canvas/element-types/text-element/text-content-editor.js
+++ b/app/components/canvas/element-types/text-element/text-content-editor.js
@@ -55,9 +55,7 @@ export default class TextContentEditor extends Component {
       return;
     }
 
-    const childNodes = Array.prototype.slice.call(this.editor.childNodes);
-
-    const nextChildren = childNodes.map((child) => {
+    const nextChildren = Array.prototype.map.call(this.editor.childNodes, (child) => {
       if (listType) {
         const { children: childElements } = child;
 

--- a/app/components/canvas/element-types/text-element/text-content-editor.js
+++ b/app/components/canvas/element-types/text-element/text-content-editor.js
@@ -233,23 +233,21 @@ export default class TextContentEditor extends Component {
         onInput={this.handleInput}
       >
         {text.map((li, i) => {
-          let listItem = li;
-          const lines = [];
           let line = "";
 
-          while (listItem.length) {
-            if (listItem.indexOf("\n") === 0) {
+          const string = li.split("").reduce((lines, character) => {
+            if (character === "\n") {
               lines.push(line);
               line = "";
             } else {
-              line += listItem[0];
+              line += character;
             }
 
-            listItem = listItem.slice(1);
-          }
+            return lines;
+          }, []);
 
           if (line.length) {
-            lines.push(line);
+            string.push(line);
           }
 
           return (
@@ -260,7 +258,7 @@ export default class TextContentEditor extends Component {
               style={style}
               key={i}
             >
-             {lines.map((str, k) => <div key={k}>{str}</div>)}
+             {string.map((str, k) => <div key={k}>{str}</div>)}
             </li>);
         })}
       </ListTag>

--- a/app/components/canvas/element-types/text-element/text-content-editor.js
+++ b/app/components/canvas/element-types/text-element/text-content-editor.js
@@ -65,7 +65,7 @@ export default class TextContentEditor extends Component {
           }
         });
 
-        return child.innerText;
+        return child.innerText.replace(/\n$/, "");
       }
 
       if (!child.children.length) {
@@ -232,35 +232,17 @@ export default class TextContentEditor extends Component {
         onKeyDown={this.handleKeyDown}
         onInput={this.handleInput}
       >
-        {text.map((li, i) => {
-          let line = "";
-
-          const string = li.split("").reduce((lines, character) => {
-            if (character === "\n") {
-              lines.push(line);
-              line = "";
-            } else {
-              line += character;
+        {text.map((li, i) => (
+          <li
+            className={
+             `${classNames.line}`
             }
-
-            return lines;
-          }, []);
-
-          if (line.length) {
-            string.push(line);
-          }
-
-          return (
-            <li
-              className={
-               `${classNames.line}`
-              }
-              style={style}
-              key={i}
-            >
-             {string.map((str, k) => <div key={k}>{str}</div>)}
-            </li>);
-        })}
+            style={style}
+            key={`list-item-${i}`}
+          >
+           {li.split("\n").map((str, k) => <div key={k}>{str}</div>)}
+          </li>
+        ))}
       </ListTag>
     );
   }

--- a/app/components/canvas/element-types/text-element/text-content-editor.js
+++ b/app/components/canvas/element-types/text-element/text-content-editor.js
@@ -69,7 +69,7 @@ export default class TextContentEditor extends Component {
       }
 
       if (!child.children.length) {
-        return child.innerText.replace(/\n$/, "") || "";
+        return child.innerText.replace(/\n$/, "");
       }
 
       return Array.prototype.map.call(child.children, (line) => line.innerText.replace(/\n$/, ""));

--- a/app/components/canvas/element-types/text-element/text-content-editor.js
+++ b/app/components/canvas/element-types/text-element/text-content-editor.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import { map } from "lodash";
 
 export default class TextContentEditor extends Component {
   static propTypes = {
@@ -48,43 +49,19 @@ export default class TextContentEditor extends Component {
     this.isHighLighted = false;
 
     const { content } = this.state;
-    const { placeholderText, children, componentProps: { listType } } = this.props;
+    const { placeholderText, children } = this.props;
 
     if (content === null || content.length === 0) {
       this.editor.childNodes[0].innerText = children && children[0] || placeholderText;
       return;
     }
 
-    const nextChildren = Array.prototype.map.call(this.editor.childNodes, (child) => {
-      if (listType) {
-        const { children: childElements } = child;
-
-        Array.prototype.forEach.call(child.children, (line, i) => {
-          if (!line.children.length && !line.innerText.length && line.localName === "div") {
-            childElements[i].innerText = "\n";
-          }
-        });
-
-        return child.innerText.replace(/\n$/, "");
-      }
-
-      if (!child.children.length) {
-        return child.innerText.replace(/\n$/, "");
-      }
-
-      return Array.prototype.map.call(child.children, (line) => line.innerText.replace(/\n$/, ""));
-    });
+    const nextChildren = map(this.editor.childNodes, (child) =>
+      child.innerText.replace(/\n$/, "")
+    );
 
     this.context.store.updateChildren(
-      nextChildren.reduce((arr, child) => {
-        if (Array.isArray(child)) {
-          return arr.concat(child);
-        }
-
-        arr.push(child);
-
-        return arr;
-      }, []),
+      nextChildren,
       this.currentSlide,
       this.currentElement
     );
@@ -240,7 +217,7 @@ export default class TextContentEditor extends Component {
             style={style}
             key={`list-item-${i}`}
           >
-           {li.split("\n").map((str, k) => <div key={k}>{str}</div>)}
+           {li.split("\n").map((str, k) => <div key={k}>{str === "" ? <br /> : str}</div>)}
           </li>
         ))}
       </ListTag>

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "shortid": "^2.2.6",
     "source-map-support": "^0.4.0",
     "spectacle": "^1.0.6",
-    "spectacle-editor-viewer": "0.0.18"
+    "spectacle-editor-viewer": "0.0.21"
   },
   "devEngines": {
     "node": "4.x || 5.x || 6.x",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "shortid": "^2.2.6",
     "source-map-support": "^0.4.0",
     "spectacle": "^1.0.6",
-    "spectacle-editor-viewer": "0.0.21"
+    "spectacle-editor-viewer": "0.0.22"
   },
   "devEngines": {
     "node": "4.x || 5.x || 6.x",


### PR DESCRIPTION
@bmathews fixes #163 

2 issues were present with this bug. Eating of empty lines when exiting edit mode and eating of multi-line list items when exiting out of edit mode. 

before--
<img width="237" alt="screen shot 2016-08-29 at 11 12 50 am" src="https://cloud.githubusercontent.com/assets/8061227/18062064/0c67cf00-6dda-11e6-84a9-5d85a06fcf76.png">

after--
<img width="378" alt="screen shot 2016-08-29 at 11 12 28 am" src="https://cloud.githubusercontent.com/assets/8061227/18062074/15079af0-6dda-11e6-8a43-5d4c857ad68f.png">
