### PR TITLE
improve blur, force input box to display src if provided

### DIFF
--- a/app/components/property-editor/contextual-menus/plotly.js
+++ b/app/components/property-editor/contextual-menus/plotly.js
@@ -2,7 +2,10 @@ import React, { Component } from "react";
 import { autorun } from "mobx";
 
 import { ElementTypes } from "../../../constants";
+import elements from "../../../elements";
 import commonStyles from "../index.css";
+
+const defaultPlotlySrc = elements[ElementTypes.PLOTLY].props.src;
 
 const normalizeUrl = (url) => {
   let urlWithEmbedAndQuery = url;
@@ -45,7 +48,8 @@ export default class PlotlyMenu extends Component {
     super(props);
 
     this.state = {
-      currentElement: null
+      currentElement: null,
+      src: null
     };
   }
 
@@ -73,20 +77,53 @@ export default class PlotlyMenu extends Component {
     if (ev.which === 13) {
       this.inputElement.blur();
     }
-  };
+  }
+
+  onSourceFocus = (ev) => {
+    window.addEventListener("click", this.handleClick);
+    ev.target.setSelectionRange(0, ev.target.value.length);
+
+    const { currentSlideIndex, currentElementIndex } = this.context.store;
+    this.currentSlideIndex = currentSlideIndex;
+    this.currentElementIndex = currentElementIndex;
+  }
+
+  onSourceChange = ({ target: { value } }) => {
+    this.setState({ src: value });
+  }
 
   onSourceBlur = ({ target: { value } }) => {
     if (!value) {
       return;
     }
 
-    this.context.store.updateElementProps({
-      src: normalizeUrl(value)
-    });
+    this.context.store.updateElementProps(
+      { src: normalizeUrl(value) },
+      this.currentSlideIndex,
+      this.currentElementIndex
+    );
+
+    this.setState({ src: null });
+  }
+
+  handleClick = (ev) => {
+    if (ev.target !== this.inputElement) {
+      this.inputElement.blur();
+      window.removeEventListener("click", this.handleClick);
+    }
   }
 
   render() {
-    const { currentElement } = this.state;
+    const { currentElement, src } = this.state;
+    let inputValue = "";
+
+    if (currentElement && defaultPlotlySrc !== currentElement.props.src) {
+      inputValue = currentElement.props.src;
+    }
+
+    if (src) {
+      inputValue = src;
+    }
 
     return (
       <div className={commonStyles.wrapper}>
@@ -103,8 +140,10 @@ export default class PlotlyMenu extends Component {
               className={`globalInput`}
               type="text"
               name="imagesSource"
-              onInput={this.onSourceInput}
+              onFocus={this.onSourceFocus}
+              onChange={this.onSourceChange}
               onBlur={this.onSourceBlur}
+              value={inputValue}
             />
           </div>
         )}

--- a/app/components/property-editor/contextual-menus/plotly.js
+++ b/app/components/property-editor/contextual-menus/plotly.js
@@ -73,6 +73,10 @@ export default class PlotlyMenu extends Component {
     });
   }
 
+  componentWillUnmount() {
+    window.removeEventListener("click", this.handleClick);
+  }
+
   onInputKeyPress = (ev) => {
     if (ev.which === 13) {
       this.inputElement.blur();

--- a/app/stores/slides-store.js
+++ b/app/stores/slides-store.js
@@ -373,13 +373,25 @@ export default class SlidesStore {
     });
   }
 
-  updateElementProps(props) {
-    if (!this.currentElement) {
+  updateElementProps(props, currentSlideIndex, currentElementIndex) {
+    const slideIndex = typeof currentSlideIndex === "number" ?
+      currentSlideIndex
+      :
+      this.currentSlideIndex;
+
+    const elementIndex = typeof currentElementIndex === "number" ?
+      currentElementIndex
+      :
+      this.currentElementIndex;
+
+    const currentElement = this.slides[slideIndex].children[elementIndex] || this.currentElement;
+
+    if (!currentElement) {
       return;
     }
 
-    const { paragraphStyle } = this.currentElement.props;
-    const newProps = merge(this.currentElement.props, props);
+    const { paragraphStyle } = currentElement.props;
+    const newProps = merge(currentElement.props, props);
     const newState = this.currentState;
 
     if (
@@ -392,7 +404,7 @@ export default class SlidesStore {
       newProps.style = omit(newProps.style, Object.keys(newState.paragraphStyles[paragraphStyle]));
     }
 
-    newState.slides[this.currentSlideIndex].children[this.currentElementIndex].props = newProps;
+    newState.slides[slideIndex].children[elementIndex].props = newProps;
     this._addToHistory(newState);
   }
 


### PR DESCRIPTION
@bmathews allow for forcing blur when clicking anywhere in window. Save slide and element indexes because current element will change to another element or `null` by the time blur event fires to update element props. Enhance `updateElementProps` to accept additional yet purely optional arguments, still performs default behavior if not provided.

also, if element is deselected and re-selected will display iframe src in input if different from default, will display updated user input if it has been provided, otherwise will default to whatever iframe src is, unless default, then blank.