### PR TITLE
Task limit image size

### DIFF
--- a/app/components/property-editor/contextual-menus/image.js
+++ b/app/components/property-editor/contextual-menus/image.js
@@ -7,6 +7,7 @@ import elements from "../../../elements";
 import { IMAGE } from "../../../assets/icons";
 import commonStyles from "../index.css";
 import styles from "./image.css";
+import notificationSystem from "../../../notifications";
 
 const defaultImageSource = elements[ElementTypes.IMAGE].props.src;
 
@@ -55,23 +56,38 @@ export default class ImageMenu extends Component {
     const imageObj = ev.target.files && ev.target.files[0];
 
     if (imageObj) {
-      const { path, type, name } = imageObj;
+      const { path, type, name, size } = imageObj;
 
-      ipcRenderer.once("image-encoded", (event, encodedImageString) => {
-        if (!encodedImageString) {
-          this.setState({ uploadError: true });
-        }
-
-        this.context.store.updateElementProps({
-          src: `data:${type};base64, ${encodedImageString}`,
-          imageName: name,
-          style: {
-            opacity: 1
+      if (size <= 3000000) {
+        ipcRenderer.once("image-encoded", (event, encodedImageString) => {
+          if (!encodedImageString) {
+            notificationSystem.addNotification({
+              message: "Error loading file",
+              level: "error"
+            });
           }
-        });
-      });
+          const imgSrc = `data:${type};base64, ${encodedImageString}`;
 
-      ipcRenderer.send("encode-image", path);
+          this.getScaledHeightAndWidth(imgSrc, ({ height, width, src }) => {
+            this.context.store.updateElementProps({
+              src,
+              imageName: name,
+              height,
+              width,
+              style: {
+                opacity: 1
+              }
+            });
+          });
+        });
+
+        ipcRenderer.send("encode-image", path);
+      } else {
+        notificationSystem.addNotification({
+          message: "Error: images must be smaller than 3MB",
+          level: "error"
+        });
+      }
     }
   }
 
@@ -79,12 +95,16 @@ export default class ImageMenu extends Component {
     const imageSrc = ev.target.value;
 
     if (imageSrc) {
-      this.context.store.updateElementProps({
-        src: imageSrc,
-        imageName: null,
-        style: {
-          opacity: 1
-        }
+      this.getScaledHeightAndWidth(imageSrc, ({ src, height, width }) => {
+        this.context.store.updateElementProps({
+          src,
+          imageName: null,
+          height,
+          width,
+          style: {
+            opacity: 1
+          }
+        });
       });
     }
   }
@@ -103,6 +123,23 @@ export default class ImageMenu extends Component {
         src: normalizedUrl
       });
     }
+  }
+
+  getScaledHeightAndWidth(src, cb) {
+    const imageElement = new Image();
+    imageElement.src = src;
+    imageElement.addEventListener("load", () => {
+      const { props } = this.context.store.currentElement;
+      const { height, width } = imageElement;
+      const aspectRatio = Math.min(height, width) / Math.max(height, width);
+
+      cb({
+        src,
+        height: height > width ? props.height : props.width * aspectRatio,
+        width: height < width ? props.width : props.height * aspectRatio,
+        aspectRatio
+      });
+    });
   }
 
   render() {

--- a/app/components/property-editor/contextual-menus/image.js
+++ b/app/components/property-editor/contextual-menus/image.js
@@ -65,7 +65,10 @@ export default class ImageMenu extends Component {
               message: "Error loading file",
               level: "error"
             });
+
+            return;
           }
+
           const imgSrc = `data:${type};base64, ${encodedImageString}`;
 
           this.getScaledHeightAndWidth(imgSrc, ({ height, width, src }) => {
@@ -128,6 +131,7 @@ export default class ImageMenu extends Component {
   getScaledHeightAndWidth(src, cb) {
     const imageElement = new Image();
     imageElement.src = src;
+
     imageElement.addEventListener("load", () => {
       const { props } = this.context.store.currentElement;
       const { height, width } = imageElement;


### PR DESCRIPTION
@bmathews #107, will only allow uploading of images if they are less than 3 megs in size, per Plotly's recommendations and upload size limits through their API.  Provides notification errors for any problems in the uploading process.  Also addresses un-reported bug where aspect ratio of original images is not preserved. This solution will scale down the current element height or width to fit the proper aspect ratio, whichever of the two is smaller.

Before--
<img width="357" alt="screen shot 2016-08-31 at 4 52 41 pm" src="https://cloud.githubusercontent.com/assets/8061227/18150436/81a87842-6f9b-11e6-9404-355da90cbad7.png">
<img width="353" alt="screen shot 2016-08-31 at 4 53 04 pm" src="https://cloud.githubusercontent.com/assets/8061227/18150440/88c89a62-6f9b-11e6-9776-9d351d81d0da.png">

After--
<img width="400" alt="screen shot 2016-08-31 at 4 52 19 pm" src="https://cloud.githubusercontent.com/assets/8061227/18150445/95ec00bc-6f9b-11e6-84da-f8fe1fde3889.png">

<img width="417" alt="screen shot 2016-08-31 at 4 51 15 pm" src="https://cloud.githubusercontent.com/assets/8061227/18150451/9fad6618-6f9b-11e6-8db9-5c7cf53e75b8.png">


