### PR TITLE
prevent bold/underline/italic in contenteditable

### DIFF
--- a/app/components/canvas/element-types/text-element/index.js
+++ b/app/components/canvas/element-types/text-element/index.js
@@ -177,6 +177,12 @@ export default class TextElement extends Component {
       this.inputElement.blur();
       this.handleBlur();
     }
+
+    if ((superKey && (e.which === 66 || e.which === 98)) || /* {cmd,ctr}+{b,B}) */
+        (superKey && (e.which === 73 || e.which === 105)) || /* {cmd,ctr}+{i,I})*/
+        (superKey && (e.which === 85 || e.which === 117))) { /* {cmd,ctr}+{u,U})*/
+      e.preventDefault();
+    }
   }
 
   // return an array of string lines, with inner <br>s converted to \n


### PR DESCRIPTION
Blocks hotkeys for rich formatting in text editor