### PR TITLE
update onprem placeholder

### DIFF
--- a/app/components/login-menu/on-premise-form.js
+++ b/app/components/login-menu/on-premise-form.js
@@ -144,7 +144,7 @@ class PlotlyForm extends Component {
                 value={this.state.domain}
                 onChange={this.handleDomainChange}
                 onBlur={this.handleDomainBlur}
-                placeholder="teamdomain.plot.ly"
+                placeholder="https://plotly.your-company.com"
               />
 
             {this.state.loadingDomain &&


### PR DESCRIPTION
Updating the on-prem placeholder to match the syntax of our [on-prem api getting started docs](https://plot.ly/python/getting-started/#special-instructions-for-plotly-onpremise-users) and adding the `https://` which some users were forgetting.