### PR TITLE
Make pre-login call to the /v2/users/current to get CSRF token

### DIFF
--- a/app/api/user.js
+++ b/app/api/user.js
@@ -9,19 +9,34 @@ const parseJSON = ({ response, text }) => {
   }
 };
 
-export const login = (domain, username, password) => fetch(`${domain}/v2/users/login`, {
-  method: "post",
+function postCreds(domain, username, password, csrfToken) {
+  return fetch(`${domain}/v2/users/login`, {
+    method: "post",
+    credentials: "include",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      "Plotly-Client-Platform": "Python 0.2",
+      "X-CSRFToken": csrfToken
+    },
+    body: JSON.stringify({
+      username,
+      password
+    })
+  });
+}
+
+export const login = (domain, username, password) => fetch(`${domain}/v2/users/current`, {
+  method: "get",
   credentials: "include",
   headers: {
     Accept: "application/json",
     "Content-Type": "application/json",
     "Plotly-Client-Platform": "Python 0.2"
-  },
-  body: JSON.stringify({
-    username,
-    password
-  })
+  }
 })
+.then(res => res.json())
+.then(userInfo => postCreds(domain, username, password, userInfo.csrf_token))
 .then(parseText)
 .then(parseJSON)
 .then(({ response, json }) => {


### PR DESCRIPTION
Make an API call to `/v2/users/current` to get a `csrf_token`. This token is then posted in the actual login API call as the `X-CSRFToken` header. The plot.ly API will start to require the XCSRFToken in all API calls. It is already being passed in the subsequent API calls made after logging in.

CC: @rgerstenberger 